### PR TITLE
CAF-2204: Fix up 'Fork Autoscale' link.

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -38,7 +38,7 @@ social:
           subtitle: Fork an Autoscale repository on GitHub and submit a pull request to help contribute to the project! Or if you have discovered an issue, report it to us.
           link:
             title: Fork Autoscale 
-            url: https://github.com/Autoscaler/autoscaler/tree/develop/autoscale-core
+            url: https://github.com/Autoscaler/autoscaler
         - icon: hpe-chat
           title: Blog
           subtitle: Follow our blog to find out all of the exciting news and announcements regarding Autoscaling.


### PR DESCRIPTION
Changing to 'Fork Autoscale' link to point to root project directory.