### PR TITLE
CAF-2941: Remove closed-source dependencies from Autoscaler

### DIFF
--- a/autoscale-container/pom.xml
+++ b/autoscale-container/pom.xml
@@ -142,7 +142,7 @@
                             <name>rh7-artifactory.svs.hpeswlab.net:8443/caf/autoscale-marathon-rabbit:${project.version}</name>
                             <build>
                                 <maintainer>andrew.reid@hpe.com</maintainer>
-                                <from>java:8</from>
+                                <from>cafinternal/prereleases:java8-with-tini-image-1.0.0-SNAPSHOT</from>
                                 <labels>
                                     <Build.Number>${project.version}</Build.Number>
                                     <Build.Date>${maven.build.timestamp}</Build.Date>
@@ -151,7 +151,7 @@
                                 </labels>
                                 <entryPoint>
                                     <exec>
-                                        <args>/maven/tini-${tini.version}.exe</args>
+                                        <args>/tini</args>
                                         <args>-v</args>
                                         <args>--</args>
                                         <args>/maven/scaler.sh</args>
@@ -177,22 +177,6 @@
                                                 <outputDirectory>config</outputDirectory>
                                             </fileSet>
                                         </fileSets>
-                                        <dependencySets>
-                                            <dependencySet>
-                                                <useProjectArtifact>false</useProjectArtifact>
-                                                <scope>runtime</scope>
-                                                <excludes>
-                                                    <exclude>com.github.krallin:tini</exclude>
-                                                </excludes>
-                                            </dependencySet>
-                                            <dependencySet>
-                                                <useProjectArtifact>false</useProjectArtifact>
-                                                <fileMode>0755</fileMode>
-                                                <includes>
-                                                    <include>com.github.krallin:tini</include>
-                                                </includes>
-                                            </dependencySet>
-                                        </dependencySets>
                                     </inline>
                                 </assembly>
                             </build>

--- a/autoscale-container/pom.xml
+++ b/autoscale-container/pom.xml
@@ -172,7 +172,7 @@
                                             </fileSet>
                                         </fileSets>
                                         <dependencySets>
-                                            <dependencySet>                                                
+                                            <dependencySet>
                                                 <useProjectArtifact>false</useProjectArtifact>
                                                 <scope>runtime</scope>
                                             </dependencySet>

--- a/autoscale-container/pom.xml
+++ b/autoscale-container/pom.xml
@@ -139,7 +139,7 @@
                     <images>
                         <image>
                             <alias>autoscale-container</alias>
-                            <name>rh7-artifactory.svs.hpeswlab.net:8443/caf/autoscale-marathon-rabbit:${project.version}</name>
+                            <name>cafinternal/prereleases:autoscale-marathon-rabbit-1.0.0-SNAPSHOT</name>
                             <build>
                                 <maintainer>andrew.reid@hpe.com</maintainer>
                                 <from>cafinternal/prereleases:java8-with-tini-image-1.0.0-SNAPSHOT</from>

--- a/autoscale-container/pom.xml
+++ b/autoscale-container/pom.xml
@@ -139,7 +139,7 @@
                     <images>
                         <image>
                             <alias>autoscale-container</alias>
-                            <name>cafinternal/prereleases:autoscale-marathon-rabbit-1.0.0-SNAPSHOT</name>
+                            <name>cafinternal/prereleases:autoscale-marathon-rabbit-${project.version}</name>
                             <build>
                                 <maintainer>andrew.reid@hpe.com</maintainer>
                                 <from>cafinternal/prereleases:java8-with-tini-image-1.0.0-SNAPSHOT</from>

--- a/autoscale-container/pom.xml
+++ b/autoscale-container/pom.xml
@@ -84,12 +84,6 @@
             <artifactId>${caf.codec.impl}</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.github.krallin</groupId>
-            <artifactId>tini</artifactId>
-            <scope>runtime</scope>
-            <type>exe</type>
-        </dependency>
-        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>
@@ -177,6 +171,12 @@
                                                 <outputDirectory>config</outputDirectory>
                                             </fileSet>
                                         </fileSets>
+                                        <dependencySets>
+                                            <dependencySet>                                                
+                                                <useProjectArtifact>false</useProjectArtifact>
+                                                <scope>runtime</scope>
+                                            </dependencySet>
+                                        </dependencySets>
                                     </inline>
                                 </assembly>
                             </build>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -119,7 +119,7 @@
                         <!-- Used to compile the source code -->
                         <image>
                             <alias>compile-source</alias>
-                            <name>rh7-artifactory.svs.hpeswlab.net:8443/caf/doc-site-compiler:1.0.0-SNAPSHOT</name>
+                            <name>cafapi/doc-site-compiler:1.0.0</name>
                             <run>
                                 <env>
                                     <!-- Enable internet access -->


### PR DESCRIPTION
* Container updated to use java8-with-tini image.
* exec arguments updated to work with tini
* Unnecessary dependencySets removed
* doc-site-compiler updated to use newly open-sourced version
* Updated the <image> tags to push to caf-internal instead of rh7-artifactory