### PR TITLE
CAF-3316 build name fix

### DIFF
--- a/autoscale-dockerswarm-container/pom.xml
+++ b/autoscale-dockerswarm-container/pom.xml
@@ -106,7 +106,7 @@
                     <images>
                         <image>
                             <alias>autoscale-container</alias>
-                            <name>${dockerCafInternalOrg}autoscale-dockerswarm-rabbit${dockerProjectVersion}</name>
+                            <name>${dockerAutoscalerOrg}autoscale-dockerswarm-rabbit${dockerProjectVersion}</name>
                             <build>
                                 <maintainer>andrew.reid@hpe.com</maintainer>
                                 <from>cafapi/java8-with-tini:1.0.0</from>

--- a/pom.xml
+++ b/pom.xml
@@ -29,13 +29,19 @@
     <name>Autoscaler</name>
     <description>Provides on-demand scaling of services, allowing you to efficiently dedicate resources where they are needed most in your Mesos cluster, and minimizing costs and ensuring user satisfaction.</description>
     <url>https://autoscaler.github.io/autoscaler/</url>
-    
+       
     <parent>
         <groupId>com.github.cafapi</groupId>
         <artifactId>caf-common</artifactId>
         <version>1.9.0-197</version>
         <relativePath />
     </parent>
+    
+    <properties>
+        <dockerHubOrganization>autoscaler</dockerHubOrganization>
+        <dockerAutoscalerOrg>${dockerImagePrefix}${dockerHubOrganization}${dockerOrgSeparator}</dockerAutoscalerOrg>
+        <dockerProjectVersion>${dockerVersionSeparator}${project.version}</dockerProjectVersion>
+    </properties>
 
     <licenses>
         <license>

--- a/pom.xml
+++ b/pom.xml
@@ -33,14 +33,14 @@
     <parent>
         <groupId>com.github.cafapi</groupId>
         <artifactId>caf-common</artifactId>
-        <version>1.9.0-197</version>
+        <version>1.13.0-239</version>
         <relativePath />
     </parent>
     
     <properties>
         <dockerHubOrganization>autoscaler</dockerHubOrganization>
-        <dockerAutoscalerOrg>${dockerImagePrefix}${dockerHubOrganization}${dockerOrgSeparator}</dockerAutoscalerOrg>
-        <dockerProjectVersion>${dockerVersionSeparator}${project.version}</dockerProjectVersion>
+        <dockerAutoscalerOrg>${dockerImagePrefix}${dockerHubOrganization}${dockerOrgSeperator}</dockerAutoscalerOrg>
+        <dockerProjectVersion>${dockerVersionSeperator}${project.version}</dockerProjectVersion>
     </properties>
 
     <licenses>


### PR DESCRIPTION
The ${dockerCafOrg} properties weren't working and causing the build to fail.

I realized that the properties were required in the top-level pom.xml as well
Also I needed to update the caf-common version to use the new properties.
I've renamed the properties to "dockerAutoscalerOrg" to coincide with the other open-sourced projects..

I was going to do this change directly in develop but thought you'd want to see what extra was required too.

my bad...