### PR TITLE
CAF-3517: Further copyright updates

### DIFF
--- a/autoscale-core/src/main/resources/banner.txt
+++ b/autoscale-core/src/main/resources/banner.txt
@@ -1,5 +1,5 @@
 ====
-    Copyright 2015-2017 Hewlett Packard Enterprise Development LP.
+    Copyright 2015-2017 EntIT Software LLC, a Micro Focus company.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/docs/_data/footer_links.json
+++ b/docs/_data/footer_links.json
@@ -8,7 +8,7 @@
         }
     }],
     "feedback_url": "https://github.com/Autoscaler/autoscaler/issues",
-    "copyright": "© 2017 Hewlett Packard Enterprise",
+    "copyright": "© 2017 EntIT Software LLC, a Micro Focus company.",
     "footer_logo": "assets/img/autoscaler-logo.png",
     "footer_columns": [{
     "title": {


### PR DESCRIPTION
Updated some other copyrights that were missed by the maven license plugin. 