### PR TITLE
CAF-3858: Enabled environment variable configured log level

### DIFF
--- a/autoscale-core/src/main/java/com/hpe/caf/autoscale/core/AutoscaleApplication.java
+++ b/autoscale-core/src/main/java/com/hpe/caf/autoscale/core/AutoscaleApplication.java
@@ -123,7 +123,7 @@ public class AutoscaleApplication extends Application<AutoscaleConfiguration>
     }
 
     @Override
-    public void initialize(Bootstrap<WorkerConfiguration> bootstrap)
+    public void initialize(Bootstrap<AutoscaleConfiguration> bootstrap)
     {
         bootstrap.setConfigurationSourceProvider(
             new SubstitutingSourceProvider(bootstrap.getConfigurationSourceProvider(), new EnvironmentVariableSubstitutor(false, true))

--- a/autoscale-core/src/main/java/com/hpe/caf/autoscale/core/AutoscaleApplication.java
+++ b/autoscale-core/src/main/java/com/hpe/caf/autoscale/core/AutoscaleApplication.java
@@ -44,6 +44,9 @@ import com.hpe.caf.naming.ServicePath;
 import com.hpe.caf.util.ModuleLoader;
 import com.hpe.caf.util.ModuleLoaderException;
 import io.dropwizard.Application;
+import io.dropwizard.configuration.EnvironmentVariableSubstitutor;
+import io.dropwizard.configuration.SubstitutingSourceProvider;
+import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -119,6 +122,13 @@ public class AutoscaleApplication extends Application<AutoscaleConfiguration>
         });
     }
 
+    @Override
+    public void initialize(Bootstrap<WorkerConfiguration> bootstrap)
+    {
+        bootstrap.setConfigurationSourceProvider(
+            new SubstitutingSourceProvider(bootstrap.getConfigurationSourceProvider(), new EnvironmentVariableSubstitutor(false, true))
+        );
+    }
 
     /**
      * Get a default implementation of a ScheduledExecutorService as used by the autoscaler.

--- a/autoscale-dockerswarm-container/README.md
+++ b/autoscale-dockerswarm-container/README.md
@@ -82,8 +82,7 @@ documentation.
 
 ### Logging
 
-Currently the logging is accessible via the docker container logs. Debug logging is enabled by default
-in this container. The default log level in this container is `INFO` and this can be configured by supplying the required level in the `CAF_LOG_LEVEL` environment variable.
+Currently the logging is accessible via the docker container logs. The default log level in this container is `INFO` and this can be configured by supplying the required level in the `CAF_LOG_LEVEL` environment variable.
 
 
 ### Scaling

--- a/autoscale-dockerswarm-container/README.md
+++ b/autoscale-dockerswarm-container/README.md
@@ -1,4 +1,4 @@
-# Autoscaler Docker Swarm Service Deployment
+# Autoscaler Docker Swarm Service Container
 
 This repository consists of the source to build a pre-defined CAF approved
 container that includes the CAF autoscale application along with
@@ -54,6 +54,10 @@ Configuration of the AutoScaler is supported through the following environment v
     Default: `5`  
     Used to specify the max length of time in seconds that the Docker endpoint healthcheck can take before a timeout occurs.
 
+ -  `CAF_LOG_LEVEL`  
+    Default: `INFO`  
+    Used to specify the required level of logging.
+
  - `HTTP_PROXY`  
     (Optional)
     Used to specify an HTTP based proxy, which is used during the Docker REST endpoint communication. 
@@ -79,7 +83,7 @@ documentation.
 ### Logging
 
 Currently the logging is accessible via the docker container logs. Debug logging is enabled by default
-in this container.  The default log level can be controlled by supplying a CAF_LOG_LEVEL environment variable value.
+in this container. The default log level in this container is `INFO` and this can be configured by supplying the required level in the `CAF_LOG_LEVEL` environment variable.
 
 
 ### Scaling

--- a/autoscale-dockerswarm-container/scaler.yaml
+++ b/autoscale-dockerswarm-container/scaler.yaml
@@ -15,6 +15,6 @@
 #
 
 logging:
-  level: INFO
+  level: ${CAF_LOG_LEVEL:-INFO}
   loggers:
-    com.hpe.caf: DEBUG
+    com.hpe.caf: ${CAF_LOG_LEVEL:-INFO}

--- a/autoscale-marathon-container/README.md
+++ b/autoscale-marathon-container/README.md
@@ -1,4 +1,4 @@
-# autoscale-container
+# Autoscaler Marathon Service Container
 
 This repository consists of the source to build a pre-defined CAF approved
 container that includes the CAF autoscale application along with
@@ -46,6 +46,10 @@ Configuration of the AutoScaler is supported through the following environment v
     Default: `100`  
     Used to specify the maximum number of instances that any worker can be scaled to.
 
+ -  `CAF_LOG_LEVEL`  
+    Default: `INFO`  
+    Used to specify the required level of logging.
+
 
 ### Health checks
 
@@ -59,9 +63,7 @@ documentation.
 
 ### Logging
 
-Currently the logging is accessible via the Marathon sandbox until a CAF
-approved logging mechanism is agreed upon. Debug logging is enabled by default
-in this container.
+Currently the logging is accessible via the Marathon sandbox. The default log level in this container is `INFO` and this can be configured by supplying the required level in the `CAF_LOG_LEVEL` environment variable.
 
 
 ### Scaling

--- a/autoscale-marathon-container/scaler.yaml
+++ b/autoscale-marathon-container/scaler.yaml
@@ -15,6 +15,6 @@
 #
 
 logging:
-  level: INFO
+  level: ${CAF_LOG_LEVEL:-INFO}
   loggers:
-    com.hpe.caf: DEBUG
+    com.hpe.caf: ${CAF_LOG_LEVEL:-INFO}


### PR DESCRIPTION
https://jira.autonomy.com/browse/CAF-3858

Default is set to INFO and the level can be changed by supplying the environment variable CAF_LOG_LEVEL

This has been tested using dev build image and the log level is respected:
http://sou-jenkins2.hpeswlab.net/job/Autoscaler/view/Developer/job/Autoscaler~autoscaler~CAF-3858_loglevel~CI/