### PR TITLE
SCMOD-5403: Update entry point and default command

### DIFF
--- a/autoscale-dockerswarm-container/pom.xml
+++ b/autoscale-dockerswarm-container/pom.xml
@@ -116,14 +116,12 @@
                                     <Git.Branch>${git.branch}</Git.Branch>
                                     <Git.Commit>${git.revision}</Git.Commit>
                                 </labels>
-                                <entryPoint>
+                                <!-- The entry point will be the worker.sh executable. -->
+                                <cmd>
                                     <exec>
-                                        <args>/tini</args>
-                                        <args>-v</args>
-                                        <args>--</args>
                                         <args>/maven/scaler.sh</args>
                                     </exec>
-                                </entryPoint>
+                                </cmd>
                                 <healthCheck>
                                     <cmd>curl --fail http://localhost:8081/healthcheck || exit 1</cmd>
                                 </healthCheck>

--- a/autoscale-marathon-container/pom.xml
+++ b/autoscale-marathon-container/pom.xml
@@ -148,14 +148,12 @@
                                     <Git.Branch>${git.branch}</Git.Branch>
                                     <Git.Commit>${git.revision}</Git.Commit>
                                 </labels>
-                                <entryPoint>
+                                <!-- The entry point will be the worker.sh executable. -->
+                                <cmd>
                                     <exec>
-                                        <args>/tini</args>
-                                        <args>-v</args>
-                                        <args>--</args>
                                         <args>/maven/scaler.sh</args>
                                     </exec>
-                                </entryPoint>
+                                </cmd>
                                 <healthCheck>
                                     <cmd>curl --fail http://localhost:8081/healthcheck || exit 1</cmd>
                                 </healthCheck>


### PR DESCRIPTION
Change done based on the [comment](https://autjira.microfocus.com/browse/SCMOD-5403?focusedCommentId=2133805&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-2133805), not sure if there is something to do for point b in the description.
http://sou-jenkins2.hpeswlab.net/job/Autoscaler/job/Autoscaler%7Eautoscaler%7ESCMOD-5403%7ECI/

Autoscaler is on start running startup.sh:
```
startup.sh: Running startup scripts...
startup.sh: Running install-ca-cert-base.sh...
install-ca-cert-base.sh: Not installing CA Certificate.
startup.sh: Running install-ca-cert-java.sh...
install-ca-cert-java.sh: Not installing CA Certificate for Java
startup.sh: Startup scripts completed
```
`/maven/scaler.sh script` is in default command:
https://docs.google.com/spreadsheets/d/1taaQ0Bm6U9TPsmMaiWM9c3vKyubOvEwod38nuWOu5vM/edit#gid=2021749445


