### PR TITLE
SCMOD-5552: Improve error recovery in scaler threads

### DIFF
--- a/autoscale-core/src/main/java/com/hpe/caf/autoscale/core/ScalerThread.java
+++ b/autoscale-core/src/main/java/com/hpe/caf/autoscale/core/ScalerThread.java
@@ -142,6 +142,11 @@ public class ScalerThread implements Runnable
             }
         } catch (ScalerException e) {
             LOG.warn("Failed analysis run for service {}", serviceRef, e);
+        } catch (RuntimeException e) {
+            // library methods have been known to throw RuntimeException when there's no programming
+            // error - but if we throw, we won't be scheduled to run again, so we must catch and
+            // ignore
+            LOG.error("Unexpected error in analysis run for service {}", serviceRef, e);
         }
     }
 

--- a/autoscale-core/src/main/java/com/hpe/caf/autoscale/core/ScalerThread.java
+++ b/autoscale-core/src/main/java/com/hpe/caf/autoscale/core/ScalerThread.java
@@ -142,7 +142,7 @@ public class ScalerThread implements Runnable
             }
         } catch (ScalerException e) {
             LOG.warn("Failed analysis run for service {}", serviceRef, e);
-        } catch (RuntimeException e) {
+        } catch (final RuntimeException e) {
             // library methods have been known to throw RuntimeException when there's no programming
             // error - but if we throw, we won't be scheduled to run again, so we must catch and
             // ignore

--- a/release-notes-1.6.0.md
+++ b/release-notes-1.6.0.md
@@ -5,4 +5,9 @@ ${version-number}
 
 #### New Features
 
+#### Bug Fixes
+
+- [SCMOD-5552](https://portal.digitalsafe.net/browse/SCMOD-5552): Autoscaler could stop scaling services  
+        After encountering certain types of issues, such as networking downtime, the Autoscaler might have failed to recover even after the issue was resolved, and would no longer perform any scaling actions.
+
 #### Known Issues


### PR DESCRIPTION
If `ScalerThread` throws, it causes `ScheduledExecutorService.scheduleWithFixedDelay` to stop running it.  We can reasonably expect that our 3rd party libraries might throw `RuntimeException` incorrectly, so I'm just catching it.  (In this particular case, `Marathon.getApp` throws `feign.RetryableException`.)

Note that this change doesn't resolve the issue for cases where the correct behaviour is less obvious, such as `OutOfMemoryError`.

----

- ticket: https://portal.digitalsafe.net/browse/SCMOD-5552
- build: http://sou-jenkins2.hpeswlab.net/job/Autoscaler/job/Autoscaler~autoscaler~SCMOD-5552~CI/