### PR TITLE
SCMOD-5552: Add health check for scheduler

### DIFF
--- a/autoscale-core/src/main/java/com/hpe/caf/autoscale/core/AutoscaleApplication.java
+++ b/autoscale-core/src/main/java/com/hpe/caf/autoscale/core/AutoscaleApplication.java
@@ -151,5 +151,7 @@ public class AutoscaleApplication extends Application<AutoscaleConfiguration>
         for ( Map.Entry<String, WorkloadAnalyserFactory> entry : core.getAnalyserFactoryMap().entrySet() ) {
             environment.healthChecks().register("workload." + entry.getKey(), new ScalerHealthCheck(entry.getValue()));
         }
+        environment.healthChecks().register("scheduler",
+            new ScalerHealthCheck(core.getAutoScaleScheduler()));
     }
 }

--- a/autoscale-core/src/main/java/com/hpe/caf/autoscale/core/AutoscaleCore.java
+++ b/autoscale-core/src/main/java/com/hpe/caf/autoscale/core/AutoscaleCore.java
@@ -145,6 +145,13 @@ public class AutoscaleCore
         return Collections.unmodifiableMap(this.analyserFactoryMap);
     }
 
+    /**
+     * @return The scheduler, which has a health check.
+     */
+    public AutoscaleScheduler getAutoScaleScheduler() {
+        return autoscaleScheduler;
+    }
+
 
     /**
      * Set or unset master status based upon a callback from an election.


### PR DESCRIPTION
- ticket: https://portal.digitalsafe.net/browse/SCMOD-5552
- build: http://sou-jenkins2.hpeswlab.net/job/Autoscaler/job/Autoscaler~autoscaler~SCMOD-5552~CI/

----

When `Error` is thrown in `ScalerThread`, we shouldn't suppress it.  There's logging for that case now, but it still causes the scheduler to stop running `ScalerThread` for the service.  This change adds a health check which detects this.

(While we shouldn't have the `ScalerThread` suppress the error, it is potentially a good idea for `AutoscaleScheduler` to restart the scheduler when this happens.  I'm not sure if it would make sense for this to happen in the health check, though, and I don't see where else it could happen.)