### PR TITLE
SCMOD-8421: Added scaling functions and rabbit query config

### DIFF
--- a/autoscale-core/src/main/java/com/hpe/caf/autoscale/core/AutoscaleScheduler.java
+++ b/autoscale-core/src/main/java/com/hpe/caf/autoscale/core/AutoscaleScheduler.java
@@ -72,7 +72,7 @@ public class AutoscaleScheduler implements HealthReporter
     private final ServiceScaler scaler;
     private static final int INITIAL_SCALING_DELAY = 30;
     private static final Logger LOG = LoggerFactory.getLogger(AutoscaleScheduler.class);
-    private final Governor governor = new GovernorImpl();
+    private final Governor governor;
     private final Map<String, AlertDispatcher> alertDispatchers;
     private final ResourceMonitoringConfiguration resourceConfig;
     private final AlertDispatchConfiguration alertConfig;
@@ -89,6 +89,9 @@ public class AutoscaleScheduler implements HealthReporter
         this.alertDispatchers = alertDispatchers;
         this.resourceConfig = resourceConfig;
         this.alertConfig = alertConfig;
+        this.governor = new GovernorImpl(resourceConfig.getResourceLimitOneShutdownThreshold(),
+                                         resourceConfig.getResourceLimitTwoShutdownThreshold(),
+                                         resourceConfig.getResourceLimitThreeShutdownThreshold());
     }
 
     /**

--- a/autoscale-core/src/main/java/com/hpe/caf/autoscale/core/Governor.java
+++ b/autoscale-core/src/main/java/com/hpe/caf/autoscale/core/Governor.java
@@ -40,11 +40,10 @@ interface Governor {
      *
      * @param serviceRef the named reference to the service for which the scaling action will be governed
      * @param action the scaling action to review
-     * @param shutdownPriority the shutdown priority of the service to be governed
      * @param currentMemoryLimitStage the current memory limit stage that the message broker is currently at
      * @return a governed ScalingAction that respects the minimum requirements of all services
      */
-    ScalingAction govern(String serviceRef, ScalingAction action, int shutdownPriority, int currentMemoryLimitStage);
+    ScalingAction govern(String serviceRef, ScalingAction action, int currentMemoryLimitStage);
 
     /**
      *

--- a/autoscale-core/src/main/java/com/hpe/caf/autoscale/core/Governor.java
+++ b/autoscale-core/src/main/java/com/hpe/caf/autoscale/core/Governor.java
@@ -37,15 +37,6 @@ interface Governor {
     void recordInstances(String serviceRef, InstanceInfo instanceInfo);
 
     /**
-     * Uses a default of -1 for service shutdown priority and a default of 0 for current memory limit stage.
-     * 
-     * @param serviceRef the named reference to the service for which the scaling action will be governed
-     * @param action the scaling action to review
-     * @return a governed ScalingAction that respects the minimum requirements of all services
-     */
-    ScalingAction govern(String serviceRef, ScalingAction action);
-
-    /**
      *
      * @param serviceRef the named reference to the service for which the scaling action will be governed
      * @param action the scaling action to review

--- a/autoscale-core/src/main/java/com/hpe/caf/autoscale/core/Governor.java
+++ b/autoscale-core/src/main/java/com/hpe/caf/autoscale/core/Governor.java
@@ -37,12 +37,23 @@ interface Governor {
     void recordInstances(String serviceRef, InstanceInfo instanceInfo);
 
     /**
-     *
+     * Uses a default of -1 for service shutdown priority and a default of 0 for current memory limit stage.
+     * 
      * @param serviceRef the named reference to the service for which the scaling action will be governed
      * @param action the scaling action to review
      * @return a governed ScalingAction that respects the minimum requirements of all services
      */
     ScalingAction govern(String serviceRef, ScalingAction action);
+
+    /**
+     *
+     * @param serviceRef the named reference to the service for which the scaling action will be governed
+     * @param action the scaling action to review
+     * @param shutdownPriority the shutdown priority of the service to be governed
+     * @param currentMemoryLimitStage the current memory limit stage that the message broker is currently at
+     * @return a governed ScalingAction that respects the minimum requirements of all services
+     */
+    ScalingAction govern(String serviceRef, ScalingAction action, int shutdownPriority, int currentMemoryLimitStage);
 
     /**
      *

--- a/autoscale-core/src/main/java/com/hpe/caf/autoscale/core/GovernorImpl.java
+++ b/autoscale-core/src/main/java/com/hpe/caf/autoscale/core/GovernorImpl.java
@@ -92,13 +92,16 @@ public class GovernorImpl implements Governor {
                     return new ScalingAction(ScalingOperation.SCALE_DOWN,
                                              lastInstanceInfo.getTotalInstances() - scalingConfiguration.getMaxInstances());
                 } else if (!otherServicesMinimumInstancesMet) {
-                    if (lastInstanceInfo.getTotalInstances() < scalingConfiguration.getMinInstances()) {
+                    if (!shouldGovern(currentMemoryLimitStage, shutdownPriority)) {
+                        final int delta = Math.min(scalingConfiguration.getMaxInstances() - lastInstanceInfo.getTotalInstances(),
+                                                   Math.max(0, action.getAmount()));
+                        return new ScalingAction(ScalingOperation.SCALE_UP, delta);
+                    } else if (lastInstanceInfo.getTotalInstances() < scalingConfiguration.getMinInstances()) {
                         return new ScalingAction(ScalingOperation.SCALE_UP,
                                                  scalingConfiguration.getMinInstances() - lastInstanceInfo.getTotalInstances());
                     } else if (lastInstanceInfo.getTotalInstances() == scalingConfiguration.getMinInstances()) {
                         return new ScalingAction(ScalingOperation.NONE, 0);
-                    } else if (lastInstanceInfo.getTotalInstances() > scalingConfiguration.getMinInstances()
-                        && shouldGovern(currentMemoryLimitStage, shutdownPriority)) {
+                    } else if (lastInstanceInfo.getTotalInstances() > scalingConfiguration.getMinInstances()) {
                         //Gradually reduce the totalInstances by a percentage until Minimums are met.
                         //This should be configurable, however there should be a Governor specific configuration
                         //to allow different Governor implementations to be added without polluting the AutoscaleConfiguration

--- a/autoscale-core/src/main/java/com/hpe/caf/autoscale/core/GovernorImpl.java
+++ b/autoscale-core/src/main/java/com/hpe/caf/autoscale/core/GovernorImpl.java
@@ -92,13 +92,13 @@ public class GovernorImpl implements Governor {
                     return new ScalingAction(ScalingOperation.SCALE_DOWN,
                                              lastInstanceInfo.getTotalInstances() - scalingConfiguration.getMaxInstances());
                 } else if (!otherServicesMinimumInstancesMet) {
-                    if (!shouldGovern(currentMemoryLimitStage, shutdownPriority)) {
+                    if (lastInstanceInfo.getTotalInstances() < scalingConfiguration.getMinInstances()) {
+                        return new ScalingAction(ScalingOperation.SCALE_UP,
+                                                 scalingConfiguration.getMinInstances() - lastInstanceInfo.getTotalInstances());
+                    } else if (!shouldGovern(currentMemoryLimitStage, shutdownPriority)) {
                         final int delta = Math.min(scalingConfiguration.getMaxInstances() - lastInstanceInfo.getTotalInstances(),
                                                    Math.max(0, action.getAmount()));
                         return new ScalingAction(ScalingOperation.SCALE_UP, delta);
-                    } else if (lastInstanceInfo.getTotalInstances() < scalingConfiguration.getMinInstances()) {
-                        return new ScalingAction(ScalingOperation.SCALE_UP,
-                                                 scalingConfiguration.getMinInstances() - lastInstanceInfo.getTotalInstances());
                     } else if (lastInstanceInfo.getTotalInstances() == scalingConfiguration.getMinInstances()) {
                         return new ScalingAction(ScalingOperation.NONE, 0);
                     } else if (lastInstanceInfo.getTotalInstances() > scalingConfiguration.getMinInstances()) {

--- a/autoscale-core/src/main/java/com/hpe/caf/autoscale/core/GovernorImpl.java
+++ b/autoscale-core/src/main/java/com/hpe/caf/autoscale/core/GovernorImpl.java
@@ -101,6 +101,7 @@ public class GovernorImpl implements Governor {
                         //Gradually reduce the totalInstances by a percentage until Minimums are met.
                         //This should be configurable, however there should be a Governor specific configuration
                         //to allow different Governor implementations to be added without polluting the AutoscaleConfiguration
+
                         int target = Math.max(scalingConfiguration.getMinInstances(),
                                               (int) Math.floor(lastInstanceInfo.getTotalInstances() * reduceToPercentage));
                         int amount = lastInstanceInfo.getTotalInstances() - target;
@@ -148,7 +149,7 @@ public class GovernorImpl implements Governor {
                 return false;
             }
             if(lastInstanceInfo.getTotalInstances() < scalingConfiguration.getMinInstances()){
-                if(isScaledDownForMemoryManagement(currentMemoryLimitStage, lastInstanceInfo.getShutdownPriority())){
+                if(shouldBeScaledDown(currentMemoryLimitStage, lastInstanceInfo.getShutdownPriority())){
                    continue;
                 }
                 return false;
@@ -157,7 +158,7 @@ public class GovernorImpl implements Governor {
         return true;
     }
 
-    private boolean isScaledDownForMemoryManagement(final int currentMemoryLoadLimit, final int shutdownPriority)
+    private boolean shouldBeScaledDown(final int currentMemoryLoadLimit, final int shutdownPriority)
     {
         if (shutdownPriority == -1) {
             return false;
@@ -173,7 +174,7 @@ public class GovernorImpl implements Governor {
                 return shutdownPriority <= stageThreeShutdownPriorityLimit;
             }
             default: {
-                return true;
+                return false;
             }
         }
     }

--- a/autoscale-core/src/main/java/com/hpe/caf/autoscale/core/GovernorImpl.java
+++ b/autoscale-core/src/main/java/com/hpe/caf/autoscale/core/GovernorImpl.java
@@ -35,13 +35,6 @@ public class GovernorImpl implements Governor {
     private final int stageOneShutdownPriorityLimit;
     private final int stageTwoShutdownPriorityLimit;
     private final int stageThreeShutdownPriorityLimit;
-    private boolean shouldGovernAlways;
-
-    public GovernorImpl()
-    {
-        this(0, 0, 0);
-        this.shouldGovernAlways = true;
-    }
 
     public GovernorImpl(final int stageOneLimit, final int stageTwoLimit, final int stageThreeLimit){
     this.instanceInfoMap = new ConcurrentHashMap<>() ;
@@ -49,7 +42,6 @@ public class GovernorImpl implements Governor {
     this.stageOneShutdownPriorityLimit = stageOneLimit;
     this.stageTwoShutdownPriorityLimit = stageTwoLimit;
     this.stageThreeShutdownPriorityLimit = stageThreeLimit;
-    this.shouldGovernAlways = false;
     }
 
     @Override
@@ -167,9 +159,6 @@ public class GovernorImpl implements Governor {
 
     private boolean shouldGovern(final int currentMemoryLoadLimit, final int shutdownPriority)
     {
-        if(shouldGovernAlways){
-           return true; 
-        }
         if (shutdownPriority == -1) {
             return false;
         }

--- a/autoscale-core/src/main/java/com/hpe/caf/autoscale/core/GovernorImpl.java
+++ b/autoscale-core/src/main/java/com/hpe/caf/autoscale/core/GovernorImpl.java
@@ -144,9 +144,11 @@ public class GovernorImpl implements Governor {
             InstanceInfo lastInstanceInfo = instanceInfoMap.getOrDefault(key, null);
 
             //If there are no instance info be cautious and assume minimum instances have not been met.
-            if(lastInstanceInfo==null || lastInstanceInfo.getTotalInstances() < scalingConfiguration.getMinInstances()){
-                if(lastInstanceInfo!= null 
-                   && isScaledDownForMemoryManagement(currentMemoryLimitStage, lastInstanceInfo.getShutdownPriority())){
+            if (lastInstanceInfo == null) {
+                return false;
+            }
+            if(lastInstanceInfo.getTotalInstances() < scalingConfiguration.getMinInstances()){
+                if(isScaledDownForMemoryManagement(currentMemoryLimitStage, lastInstanceInfo.getShutdownPriority())){
                    continue;
                 }
                 return false;

--- a/autoscale-core/src/main/java/com/hpe/caf/autoscale/core/GovernorImpl.java
+++ b/autoscale-core/src/main/java/com/hpe/caf/autoscale/core/GovernorImpl.java
@@ -36,12 +36,13 @@ public class GovernorImpl implements Governor {
     private final int stageTwoShutdownPriorityLimit;
     private final int stageThreeShutdownPriorityLimit;
 
-    public GovernorImpl(final int stageOneLimit, final int stageTwoLimit, final int stageThreeLimit){
-    this.instanceInfoMap = new ConcurrentHashMap<>() ;
-    this.scalingConfigurationMap = new ConcurrentHashMap<>();
-    this.stageOneShutdownPriorityLimit = stageOneLimit;
-    this.stageTwoShutdownPriorityLimit = stageTwoLimit;
-    this.stageThreeShutdownPriorityLimit = stageThreeLimit;
+    public GovernorImpl(final int stageOneLimit, final int stageTwoLimit, final int stageThreeLimit)
+    {
+        this.instanceInfoMap = new ConcurrentHashMap<>();
+        this.scalingConfigurationMap = new ConcurrentHashMap<>();
+        this.stageOneShutdownPriorityLimit = stageOneLimit;
+        this.stageTwoShutdownPriorityLimit = stageTwoLimit;
+        this.stageThreeShutdownPriorityLimit = stageThreeLimit;
     }
 
     @Override

--- a/autoscale-core/src/main/java/com/hpe/caf/autoscale/core/GovernorImpl.java
+++ b/autoscale-core/src/main/java/com/hpe/caf/autoscale/core/GovernorImpl.java
@@ -61,11 +61,6 @@ public class GovernorImpl implements Governor {
     }
 
     @Override
-    public ScalingAction govern(final String serviceRef, final ScalingAction action){
-        return govern(serviceRef, action, -1, 0);
-    }
-
-    @Override
     public ScalingAction govern(String serviceRef, ScalingAction action, final int shutdownPriority, final int currentMemoryLimitStage) {
 
         ScalingConfiguration scalingConfiguration = scalingConfigurationMap.getOrDefault(serviceRef, null);

--- a/autoscale-core/src/main/java/com/hpe/caf/autoscale/core/ScalerThread.java
+++ b/autoscale-core/src/main/java/com/hpe/caf/autoscale/core/ScalerThread.java
@@ -118,7 +118,7 @@ public class ScalerThread implements Runnable
             action = analyser.analyseWorkload(instances);
             LOG.debug("Workload Analyser determined that the autoscaler should {} {} by {} instances",
                      action.getOperation(), serviceRef, action.getAmount());
-            action = governor.govern(serviceRef, action, shutdownPriority, currentMemoryLimitStage);
+            action = governor.govern(serviceRef, action, currentMemoryLimitStage);
             LOG.debug("Governor determined that the autoscaler should {} {} by {} instances",
                      action.getOperation(), serviceRef, action.getAmount());
             switch (action.getOperation()) {

--- a/autoscale-core/src/main/java/com/hpe/caf/autoscale/core/ScalerThread.java
+++ b/autoscale-core/src/main/java/com/hpe/caf/autoscale/core/ScalerThread.java
@@ -208,14 +208,12 @@ public class ScalerThread implements Runnable
     
     private int establishMemLimitReached(final double currentMemoryLoad)
     {
-        if (currentMemoryLoad >= resourceConfig.getResourceLimitOne()
-            && currentMemoryLoad < resourceConfig.getResourceLimitTwo()) {
-            return 1;
-        } else if (currentMemoryLoad >= resourceConfig.getResourceLimitTwo()
-            && currentMemoryLoad < resourceConfig.getResourceLimitThree()) {
-            return 2;
-        } else if (currentMemoryLoad >= resourceConfig.getResourceLimitThree()) {
+        if (currentMemoryLoad >= resourceConfig.getResourceLimitThree()) {
             return 3;
+        } else if (currentMemoryLoad >= resourceConfig.getResourceLimitTwo()) {
+            return 2;
+        } else if (currentMemoryLoad >= resourceConfig.getResourceLimitOne()) {
+            return 1;
         }
         return 0;
     }

--- a/autoscale-core/src/main/java/com/hpe/caf/autoscale/core/ScalerThread.java
+++ b/autoscale-core/src/main/java/com/hpe/caf/autoscale/core/ScalerThread.java
@@ -189,16 +189,13 @@ public class ScalerThread implements Runnable
 
         handleAlerterDispatch(currentMemoryLoadLimit);
 
-        if (currentMemoryLoad >= resourceConfig.getResourceLimitOne()
-            && shutdownPriority <= resourceConfig.getResourceLimitOneShutdownThreshold()) {
+        if (currentMemoryLoadLimit == 1 && shutdownPriority <= resourceConfig.getResourceLimitOneShutdownThreshold()) {
             scaleDown(instances.getTotalInstances());
             return true;
-        } else if (currentMemoryLoad >= resourceConfig.getResourceLimitTwo()
-            && shutdownPriority <= resourceConfig.getResourceLimitTwoShutdownThreshold()) {
+        } else if (currentMemoryLoadLimit == 2 && shutdownPriority <= resourceConfig.getResourceLimitTwoShutdownThreshold()) {
             scaleDown(instances.getTotalInstances());
             return true;
-        } else if (currentMemoryLoad >= resourceConfig.getResourceLimitThree()
-            && shutdownPriority <= resourceConfig.getResourceLimitThreeShutdownThreshold()) {
+        } else if (currentMemoryLoadLimit == 3 && shutdownPriority <= resourceConfig.getResourceLimitThreeShutdownThreshold()) {
             scaleDown(instances.getTotalInstances());
             return true;
         }

--- a/autoscale-core/src/main/java/com/hpe/caf/autoscale/core/ScalerThread.java
+++ b/autoscale-core/src/main/java/com/hpe/caf/autoscale/core/ScalerThread.java
@@ -208,7 +208,8 @@ public class ScalerThread implements Runnable
     
     private int establishMemLimitReached(final double currentMemoryLoad)
     {
-        if (currentMemoryLoad >= resourceConfig.getResourceLimitOne() && currentMemoryLoad < resourceConfig.getResourceLimitTwo()) {
+        if (currentMemoryLoad >= resourceConfig.getResourceLimitOne()
+            && currentMemoryLoad < resourceConfig.getResourceLimitTwo()) {
             return 1;
         } else if (currentMemoryLoad >= resourceConfig.getResourceLimitTwo()
             && currentMemoryLoad < resourceConfig.getResourceLimitThree()) {

--- a/autoscale-core/src/test/java/com/hpe/caf/autoscale/core/GovernorImplTest.java
+++ b/autoscale-core/src/test/java/com/hpe/caf/autoscale/core/GovernorImplTest.java
@@ -35,7 +35,7 @@ public class GovernorImplTest {
      */
     @Test
     public void testSingleServiceShouldNotOverrideScaleUpWhenMinimumNotReached() {
-        final Governor governor = new GovernorImpl();
+        final Governor governor = new GovernorImpl(1, 3, 5);
         final ScalingConfiguration scalingConfigurationForServiceOne = new ScalingConfiguration();
         scalingConfigurationForServiceOne.setBackoffAmount(1000);
         scalingConfigurationForServiceOne.setId("service1");
@@ -74,7 +74,7 @@ public class GovernorImplTest {
      */
     @Test
     public void testSingleServiceShouldNotOverrideScaleUp() {
-        final Governor governor = new GovernorImpl();
+        final Governor governor = new GovernorImpl(1, 3, 5);
         final ScalingConfiguration scalingConfiguration = new ScalingConfiguration();
         scalingConfiguration.setBackoffAmount(1000);
         scalingConfiguration.setId("service1");
@@ -102,7 +102,7 @@ public class GovernorImplTest {
      */
     @Test
     public void testSingleServiceShouldOverrideScaleUp() {
-        final Governor governor = new GovernorImpl();
+        final Governor governor = new GovernorImpl(1, 3, 5);
         final ScalingConfiguration scalingConfiguration = new ScalingConfiguration();
         scalingConfiguration.setBackoffAmount(1000);
         scalingConfiguration.setId("service1");
@@ -130,7 +130,7 @@ public class GovernorImplTest {
      */
     @Test
     public void testSingleServiceShouldNotOverrideScaleDown() {
-        final Governor governor = new GovernorImpl();
+        final Governor governor = new GovernorImpl(1, 3, 5);
         final ScalingConfiguration scalingConfiguration = new ScalingConfiguration();
         scalingConfiguration.setBackoffAmount(1000);
         scalingConfiguration.setId("service1");
@@ -158,7 +158,7 @@ public class GovernorImplTest {
      */
     @Test
     public void testSingleServiceShouldOverrideScaleDown() {
-        final Governor governor = new GovernorImpl();
+        final Governor governor = new GovernorImpl(1, 3, 5);
         final ScalingConfiguration scalingConfiguration = new ScalingConfiguration();
         scalingConfiguration.setBackoffAmount(1000);
         scalingConfiguration.setId("service1");
@@ -185,7 +185,7 @@ public class GovernorImplTest {
      */
     @Test
     public void testSingleServiceShouldNotOverrideScaleNone() {
-        final Governor governor = new GovernorImpl();
+        final Governor governor = new GovernorImpl(1, 3, 5);
         final ScalingConfiguration scalingConfiguration = new ScalingConfiguration();
         scalingConfiguration.setBackoffAmount(1000);
         scalingConfiguration.setId("service1");
@@ -213,7 +213,7 @@ public class GovernorImplTest {
      */
     @Test
     public void testSingleServiceShouldOverrideScaleNoneUnderLimit() {
-        final Governor governor = new GovernorImpl();
+        final Governor governor = new GovernorImpl(1, 3, 5);
         final ScalingConfiguration scalingConfiguration = new ScalingConfiguration();
         scalingConfiguration.setBackoffAmount(1000);
         scalingConfiguration.setId("service1");
@@ -242,7 +242,7 @@ public class GovernorImplTest {
      */
     @Test
     public void testSingleServiceShouldOverrideScaleNoneOverLimit() {
-        final Governor governor = new GovernorImpl();
+        final Governor governor = new GovernorImpl(1, 3, 5);
         final ScalingConfiguration scalingConfiguration = new ScalingConfiguration();
         scalingConfiguration.setBackoffAmount(1000);
         scalingConfiguration.setId("service1");
@@ -270,7 +270,7 @@ public class GovernorImplTest {
      */
     @Test
     public void testMultipleServicesPreventScaleUp() {
-        Governor governor = new GovernorImpl();
+        Governor governor = new GovernorImpl(1, 3, 5);
         int service1StartingInstances = 150;
         int service1CurrentInstances = service1StartingInstances;
 

--- a/autoscale-core/src/test/java/com/hpe/caf/autoscale/core/GovernorImplTest.java
+++ b/autoscale-core/src/test/java/com/hpe/caf/autoscale/core/GovernorImplTest.java
@@ -63,7 +63,7 @@ public class GovernorImplTest {
 
         final ScalingAction scalingAction = new ScalingAction(ScalingOperation.SCALE_UP, 1);
 
-        final ScalingAction governedAction = governor.govern(scalingConfigurationForServiceOne.getId(), scalingAction, -1, 0);
+        final ScalingAction governedAction = governor.govern(scalingConfigurationForServiceOne.getId(), scalingAction, 0);
 
         Assert.assertEquals(3, governedAction.getAmount());
         Assert.assertEquals(SCALE_UP, governedAction.getOperation().toString());
@@ -91,7 +91,7 @@ public class GovernorImplTest {
 
         final ScalingAction scalingAction = new ScalingAction(ScalingOperation.SCALE_UP, 1);
 
-        final ScalingAction governedAction = governor.govern(scalingConfiguration.getId(), scalingAction, -1, 0);
+        final ScalingAction governedAction = governor.govern(scalingConfiguration.getId(), scalingAction, 0);
 
         Assert.assertEquals(1, governedAction.getAmount());
         Assert.assertEquals(SCALE_UP, governedAction.getOperation().toString());
@@ -119,7 +119,7 @@ public class GovernorImplTest {
 
         final ScalingAction scalingAction = new ScalingAction(ScalingOperation.SCALE_UP, 10);
 
-        final ScalingAction governedAction = governor.govern(scalingConfiguration.getId(), scalingAction, -1, 0);
+        final ScalingAction governedAction = governor.govern(scalingConfiguration.getId(), scalingAction, 0);
 
         Assert.assertEquals(140, governedAction.getAmount());
         Assert.assertEquals(SCALE_DOWN, governedAction.getOperation().toString());
@@ -147,7 +147,7 @@ public class GovernorImplTest {
 
         final ScalingAction scalingAction = new ScalingAction(ScalingOperation.SCALE_DOWN, 1);
 
-        final ScalingAction governedAction = governor.govern(scalingConfiguration.getId(), scalingAction, -1, 0);
+        final ScalingAction governedAction = governor.govern(scalingConfiguration.getId(), scalingAction, 0);
 
         Assert.assertEquals(1, governedAction.getAmount());
         Assert.assertEquals(SCALE_DOWN, governedAction.getOperation().toString());
@@ -175,7 +175,7 @@ public class GovernorImplTest {
 
         final ScalingAction scalingAction = new ScalingAction(ScalingOperation.SCALE_DOWN, 1);
 
-        final ScalingAction governedAction = governor.govern(scalingConfiguration.getId(), scalingAction, -1, 0);
+        final ScalingAction governedAction = governor.govern(scalingConfiguration.getId(), scalingAction, 0);
 
         Assert.assertEquals(0, governedAction.getAmount());
         Assert.assertEquals(NONE, governedAction.getOperation().toString());
@@ -202,7 +202,7 @@ public class GovernorImplTest {
 
         final ScalingAction scalingAction = new ScalingAction(ScalingOperation.NONE, 0);
 
-        final ScalingAction governedAction = governor.govern(scalingConfiguration.getId(), scalingAction, -1, 0);
+        final ScalingAction governedAction = governor.govern(scalingConfiguration.getId(), scalingAction, 0);
 
         Assert.assertEquals(0, governedAction.getAmount());
         Assert.assertEquals(NONE, governedAction.getOperation().toString());
@@ -230,7 +230,7 @@ public class GovernorImplTest {
 
         final ScalingAction scalingAction = new ScalingAction(ScalingOperation.NONE, 0);
 
-        final ScalingAction governedAction = governor.govern(scalingConfiguration.getId(), scalingAction, -1, 0);
+        final ScalingAction governedAction = governor.govern(scalingConfiguration.getId(), scalingAction, 0);
 
         Assert.assertEquals(1, governedAction.getAmount());
         Assert.assertEquals(SCALE_UP, governedAction.getOperation().toString());
@@ -259,7 +259,7 @@ public class GovernorImplTest {
 
         final ScalingAction scalingAction = new ScalingAction(ScalingOperation.NONE, 0);
 
-        final ScalingAction governedAction = governor.govern(scalingConfiguration.getId(), scalingAction, -1, 0);
+        final ScalingAction governedAction = governor.govern(scalingConfiguration.getId(), scalingAction, 0);
 
         Assert.assertEquals(1, governedAction.getAmount());
         Assert.assertEquals(SCALE_DOWN, governedAction.getOperation().toString());
@@ -304,7 +304,7 @@ public class GovernorImplTest {
         }
 
         ScalingAction scalingAction = new ScalingAction(ScalingOperation.SCALE_UP, 100);
-        ScalingAction governedAction = governor.govern("service1", scalingAction, -1, 0);
+        ScalingAction governedAction = governor.govern("service1", scalingAction, 0);
         Assert.assertEquals(ScalingOperation.SCALE_DOWN, governedAction.getOperation());
         Assert.assertTrue(governedAction.getAmount()>0);
         service1CurrentInstances = service1CurrentInstances - governedAction.getAmount();
@@ -315,7 +315,7 @@ public class GovernorImplTest {
 
             //The service still wishes to scale up
             scalingAction = new ScalingAction(ScalingOperation.SCALE_UP, 100);
-            governedAction = governor.govern("service1", scalingAction, -1, 0);
+            governedAction = governor.govern("service1", scalingAction, 0);
             service1CurrentInstances = service1CurrentInstances - governedAction.getAmount();
 
             System.out.println(String.format("Current instances %d", service1CurrentInstances));
@@ -355,7 +355,7 @@ public class GovernorImplTest {
 
         final ScalingAction scalingAction = new ScalingAction(ScalingOperation.SCALE_UP, 3);
 
-        final ScalingAction governedAction = governor.govern(scalingConfigurationForServiceOne.getId(), scalingAction, 3, 1);
+        final ScalingAction governedAction = governor.govern(scalingConfigurationForServiceOne.getId(), scalingAction, 1);
 
         Assert.assertEquals(3, governedAction.getAmount());
         Assert.assertEquals(SCALE_UP, governedAction.getOperation().toString());
@@ -387,14 +387,14 @@ public class GovernorImplTest {
         governor.register(scalingConfigurationForServiceOne);
         governor.register(scalingConfigurationForServiceTwo);
 
-        final InstanceInfo firstServiceInstanceInfo = new InstanceInfo(0, 0, Collections.emptyList());
+        final InstanceInfo firstServiceInstanceInfo = new InstanceInfo(0, 0, Collections.emptyList(), 1);
         governor.recordInstances(scalingConfigurationForServiceOne.getId(), firstServiceInstanceInfo);
         final InstanceInfo secondServiceInstanceInfo = new InstanceInfo(1, 0, Collections.emptyList());
         governor.recordInstances(scalingConfigurationForServiceTwo.getId(), secondServiceInstanceInfo);
 
         final ScalingAction scalingAction = new ScalingAction(ScalingOperation.SCALE_UP, 3);
 
-        final ScalingAction governedAction = governor.govern(scalingConfigurationForServiceTwo.getId(), scalingAction, 3, 1);
+        final ScalingAction governedAction = governor.govern(scalingConfigurationForServiceTwo.getId(), scalingAction, 1);
 
         Assert.assertEquals(2, governedAction.getAmount());
         Assert.assertEquals(SCALE_UP, governedAction.getOperation().toString());

--- a/autoscale-core/src/test/java/com/hpe/caf/autoscale/core/GovernorImplTest.java
+++ b/autoscale-core/src/test/java/com/hpe/caf/autoscale/core/GovernorImplTest.java
@@ -63,7 +63,7 @@ public class GovernorImplTest {
 
         final ScalingAction scalingAction = new ScalingAction(ScalingOperation.SCALE_UP, 1);
 
-        final ScalingAction governedAction = governor.govern(scalingConfigurationForServiceOne.getId(), scalingAction);
+        final ScalingAction governedAction = governor.govern(scalingConfigurationForServiceOne.getId(), scalingAction, -1, 0);
 
         Assert.assertEquals(3, governedAction.getAmount());
         Assert.assertEquals(SCALE_UP, governedAction.getOperation().toString());
@@ -91,7 +91,7 @@ public class GovernorImplTest {
 
         final ScalingAction scalingAction = new ScalingAction(ScalingOperation.SCALE_UP, 1);
 
-        final ScalingAction governedAction = governor.govern(scalingConfiguration.getId(), scalingAction);
+        final ScalingAction governedAction = governor.govern(scalingConfiguration.getId(), scalingAction, -1, 0);
 
         Assert.assertEquals(1, governedAction.getAmount());
         Assert.assertEquals(SCALE_UP, governedAction.getOperation().toString());
@@ -119,7 +119,7 @@ public class GovernorImplTest {
 
         final ScalingAction scalingAction = new ScalingAction(ScalingOperation.SCALE_UP, 10);
 
-        final ScalingAction governedAction = governor.govern(scalingConfiguration.getId(), scalingAction);
+        final ScalingAction governedAction = governor.govern(scalingConfiguration.getId(), scalingAction, -1, 0);
 
         Assert.assertEquals(140, governedAction.getAmount());
         Assert.assertEquals(SCALE_DOWN, governedAction.getOperation().toString());
@@ -147,7 +147,7 @@ public class GovernorImplTest {
 
         final ScalingAction scalingAction = new ScalingAction(ScalingOperation.SCALE_DOWN, 1);
 
-        final ScalingAction governedAction = governor.govern(scalingConfiguration.getId(), scalingAction);
+        final ScalingAction governedAction = governor.govern(scalingConfiguration.getId(), scalingAction, -1, 0);
 
         Assert.assertEquals(1, governedAction.getAmount());
         Assert.assertEquals(SCALE_DOWN, governedAction.getOperation().toString());
@@ -175,7 +175,7 @@ public class GovernorImplTest {
 
         final ScalingAction scalingAction = new ScalingAction(ScalingOperation.SCALE_DOWN, 1);
 
-        final ScalingAction governedAction = governor.govern(scalingConfiguration.getId(), scalingAction);
+        final ScalingAction governedAction = governor.govern(scalingConfiguration.getId(), scalingAction, -1, 0);
 
         Assert.assertEquals(0, governedAction.getAmount());
         Assert.assertEquals(NONE, governedAction.getOperation().toString());
@@ -202,7 +202,7 @@ public class GovernorImplTest {
 
         final ScalingAction scalingAction = new ScalingAction(ScalingOperation.NONE, 0);
 
-        final ScalingAction governedAction = governor.govern(scalingConfiguration.getId(), scalingAction);
+        final ScalingAction governedAction = governor.govern(scalingConfiguration.getId(), scalingAction, -1, 0);
 
         Assert.assertEquals(0, governedAction.getAmount());
         Assert.assertEquals(NONE, governedAction.getOperation().toString());
@@ -230,7 +230,7 @@ public class GovernorImplTest {
 
         final ScalingAction scalingAction = new ScalingAction(ScalingOperation.NONE, 0);
 
-        final ScalingAction governedAction = governor.govern(scalingConfiguration.getId(), scalingAction);
+        final ScalingAction governedAction = governor.govern(scalingConfiguration.getId(), scalingAction, -1, 0);
 
         Assert.assertEquals(1, governedAction.getAmount());
         Assert.assertEquals(SCALE_UP, governedAction.getOperation().toString());
@@ -259,7 +259,7 @@ public class GovernorImplTest {
 
         final ScalingAction scalingAction = new ScalingAction(ScalingOperation.NONE, 0);
 
-        final ScalingAction governedAction = governor.govern(scalingConfiguration.getId(), scalingAction);
+        final ScalingAction governedAction = governor.govern(scalingConfiguration.getId(), scalingAction, -1, 0);
 
         Assert.assertEquals(1, governedAction.getAmount());
         Assert.assertEquals(SCALE_DOWN, governedAction.getOperation().toString());
@@ -304,7 +304,7 @@ public class GovernorImplTest {
         }
 
         ScalingAction scalingAction = new ScalingAction(ScalingOperation.SCALE_UP, 100);
-        ScalingAction governedAction = governor.govern("service1", scalingAction);
+        ScalingAction governedAction = governor.govern("service1", scalingAction, -1, 0);
         Assert.assertEquals(ScalingOperation.SCALE_DOWN, governedAction.getOperation());
         Assert.assertTrue(governedAction.getAmount()>0);
         service1CurrentInstances = service1CurrentInstances - governedAction.getAmount();
@@ -315,7 +315,7 @@ public class GovernorImplTest {
 
             //The service still wishes to scale up
             scalingAction = new ScalingAction(ScalingOperation.SCALE_UP, 100);
-            governedAction = governor.govern("service1", scalingAction);
+            governedAction = governor.govern("service1", scalingAction, -1, 0);
             service1CurrentInstances = service1CurrentInstances - governedAction.getAmount();
 
             System.out.println(String.format("Current instances %d", service1CurrentInstances));

--- a/autoscale-core/src/test/java/com/hpe/caf/autoscale/core/ScalerThreadTest.java
+++ b/autoscale-core/src/test/java/com/hpe/caf/autoscale/core/ScalerThreadTest.java
@@ -19,7 +19,6 @@ package com.hpe.caf.autoscale.core;
 import com.hpe.caf.api.autoscale.InstanceInfo;
 import com.hpe.caf.api.autoscale.ScalerException;
 import com.hpe.caf.api.autoscale.ScalingAction;
-import com.hpe.caf.api.autoscale.ScalingOperation;
 import com.hpe.caf.api.autoscale.ServiceScaler;
 import com.hpe.caf.api.autoscale.WorkloadAnalyser;
 import java.util.HashMap;
@@ -44,7 +43,7 @@ public class ScalerThreadTest
         InstanceInfo info = new InstanceInfo(1, 0, new LinkedList<>());
         Mockito.when(scaler.getInstanceInfo(SERVICE_REF)).thenReturn(info);
         Governor governor = Mockito.mock(Governor.class);
-        Mockito.when(governor.govern(Mockito.anyString(), Mockito.any())).then(returnsSecondArg());
+        Mockito.when(governor.govern(Mockito.anyString(), Mockito.any(), Mockito.anyInt(), Mockito.anyInt())).then(returnsSecondArg());
 
         int min = 0;
         int max = 5;
@@ -66,13 +65,14 @@ public class ScalerThreadTest
         InstanceInfo info = new InstanceInfo(1, 0, new LinkedList<>());
         Mockito.when(scaler.getInstanceInfo(SERVICE_REF)).thenReturn(info);
         Governor governor = Mockito.mock(Governor.class);
-        Mockito.when(governor.govern(Mockito.anyString(), Mockito.any())).then(returnsSecondArg());
+        Mockito.when(governor.govern(Mockito.anyString(), Mockito.any(), Mockito.anyInt(), Mockito.anyInt())).then(returnsSecondArg());
 
         int min = 0;
         int max = 5;
         ScalerThread t = new ScalerThread(governor, analyser, scaler, SERVICE_REF, min, max, 0, 
             new Alerter(new HashMap<>(), new AlertDispatchConfiguration()), new ResourceMonitoringConfiguration());
-        Mockito.when(analyser.analyseWorkload(info)).thenReturn(new ScalingAction(ScalingOperation.SCALE_UP, 1));
+        t.run();
+        Mockito.when(analyser.analyseWorkload(info)).thenReturn(ScalingAction.SCALE_DOWN);
         t.run();
         Mockito.verify(scaler, Mockito.times(1)).scaleDown(SERVICE_REF, 1);
     }

--- a/autoscale-core/src/test/java/com/hpe/caf/autoscale/core/ScalerThreadTest.java
+++ b/autoscale-core/src/test/java/com/hpe/caf/autoscale/core/ScalerThreadTest.java
@@ -87,7 +87,7 @@ public class ScalerThreadTest
         InstanceInfo info = new InstanceInfo(1, 0, new LinkedList<>());
         Mockito.when(scaler.getInstanceInfo(SERVICE_REF)).thenReturn(info);
         Governor governor = Mockito.mock(Governor.class);
-        Mockito.when(governor.govern(Mockito.anyString(), Mockito.any())).then(returnsSecondArg());
+        Mockito.when(governor.govern(Mockito.anyString(), Mockito.any(), Mockito.anyInt(), Mockito.anyInt())).then(returnsSecondArg());
 
         int min = 0;
         int max = 5;
@@ -108,7 +108,7 @@ public class ScalerThreadTest
         Mockito.when(scaler.getInstanceInfo(SERVICE_REF))
             .thenThrow(new RuntimeException("network error"));
         Governor governor = Mockito.mock(Governor.class);
-        Mockito.when(governor.govern(Mockito.anyString(), Mockito.any())).then(returnsSecondArg());
+        Mockito.when(governor.govern(Mockito.anyString(), Mockito.any(), Mockito.anyInt(), Mockito.anyInt())).then(returnsSecondArg());
 
         int min = 0;
         int max = 5;

--- a/autoscale-core/src/test/java/com/hpe/caf/autoscale/core/ScalerThreadTest.java
+++ b/autoscale-core/src/test/java/com/hpe/caf/autoscale/core/ScalerThreadTest.java
@@ -43,7 +43,7 @@ public class ScalerThreadTest
         InstanceInfo info = new InstanceInfo(1, 0, new LinkedList<>());
         Mockito.when(scaler.getInstanceInfo(SERVICE_REF)).thenReturn(info);
         Governor governor = Mockito.mock(Governor.class);
-        Mockito.when(governor.govern(Mockito.anyString(), Mockito.any(), Mockito.anyInt(), Mockito.anyInt())).then(returnsSecondArg());
+        Mockito.when(governor.govern(Mockito.anyString(), Mockito.any(), Mockito.anyInt())).then(returnsSecondArg());
 
         int min = 0;
         int max = 5;
@@ -65,7 +65,7 @@ public class ScalerThreadTest
         InstanceInfo info = new InstanceInfo(1, 0, new LinkedList<>());
         Mockito.when(scaler.getInstanceInfo(SERVICE_REF)).thenReturn(info);
         Governor governor = Mockito.mock(Governor.class);
-        Mockito.when(governor.govern(Mockito.anyString(), Mockito.any(), Mockito.anyInt(), Mockito.anyInt())).then(returnsSecondArg());
+        Mockito.when(governor.govern(Mockito.anyString(), Mockito.any(), Mockito.anyInt())).then(returnsSecondArg());
 
         int min = 0;
         int max = 5;
@@ -87,7 +87,7 @@ public class ScalerThreadTest
         InstanceInfo info = new InstanceInfo(1, 0, new LinkedList<>());
         Mockito.when(scaler.getInstanceInfo(SERVICE_REF)).thenReturn(info);
         Governor governor = Mockito.mock(Governor.class);
-        Mockito.when(governor.govern(Mockito.anyString(), Mockito.any(), Mockito.anyInt(), Mockito.anyInt())).then(returnsSecondArg());
+        Mockito.when(governor.govern(Mockito.anyString(), Mockito.any(), Mockito.anyInt())).then(returnsSecondArg());
 
         int min = 0;
         int max = 5;
@@ -108,7 +108,7 @@ public class ScalerThreadTest
         Mockito.when(scaler.getInstanceInfo(SERVICE_REF))
             .thenThrow(new RuntimeException("network error"));
         Governor governor = Mockito.mock(Governor.class);
-        Mockito.when(governor.govern(Mockito.anyString(), Mockito.any(), Mockito.anyInt(), Mockito.anyInt())).then(returnsSecondArg());
+        Mockito.when(governor.govern(Mockito.anyString(), Mockito.any(), Mockito.anyInt())).then(returnsSecondArg());
 
         int min = 0;
         int max = 5;

--- a/autoscale-core/src/test/java/com/hpe/caf/autoscale/core/ScalerThreadTest.java
+++ b/autoscale-core/src/test/java/com/hpe/caf/autoscale/core/ScalerThreadTest.java
@@ -72,8 +72,7 @@ public class ScalerThreadTest
         int max = 5;
         ScalerThread t = new ScalerThread(governor, analyser, scaler, SERVICE_REF, min, max, 0, 
             new Alerter(new HashMap<>(), new AlertDispatchConfiguration()), new ResourceMonitoringConfiguration());
-        t.run();
-        Mockito.when(analyser.analyseWorkload(info)).thenReturn(ScalingAction.SCALE_DOWN);
+        Mockito.when(analyser.analyseWorkload(info)).thenReturn(new ScalingAction(ScalingOperation.SCALE_UP, 1));
         t.run();
         Mockito.verify(scaler, Mockito.times(1)).scaleDown(SERVICE_REF, 1);
     }

--- a/autoscale-marathon-container/README.md
+++ b/autoscale-marathon-container/README.md
@@ -27,7 +27,11 @@ Configuration of the AutoScaler is supported through the following environment v
 
  - `CAF_RABBITMQ_MGMT_PASSWORD`  
     Default: `guest`  
-    Used to specify the password used to connect to RabbitMQ.  If `CAF_RABBITMQ_MGMT_PASSWORD` is not specified then `CAF_RABBITMQ_PASSWORD` will also be checked before falling back to the default.
+    Used to specify the password used to connect to RabbitMQ.  If `CAF_RABBITMQ_MGMT_PASSWORD` is not specified then `CAF_RABBITMQ_PASSWORD` will also be checked before falling back to the default.  
+
+ - `CAF_AUTOSCALER_RABBITMQ_MEMORY_QUERY_FREQ`  
+    Default: `10`  
+    Number of whole seconds that the service should wait between sending RabbitMQ memory status requests.
 
  - `CAF_AUTOSCALER_MARATHON_GROUP`  
     Defaults to the group where the autoscaler itself is deployed  

--- a/autoscale-marathon-container/src/main/config/cfg~caf~autoscaler~RabbitWorkloadAnalyserConfiguration.js
+++ b/autoscale-marathon-container/src/main/config/cfg~caf~autoscaler~RabbitWorkloadAnalyserConfiguration.js
@@ -18,7 +18,7 @@
             || ("http://" + (getenv("CAF_RABBITMQ_HOST") || "rabbitmq") + ":" + (getenv("CAF_RABBITMQ_MGMT_PORT") || "15672")),
     rabbitManagementUser: getenv("CAF_RABBITMQ_MGMT_USERNAME") || getenv("CAF_RABBITMQ_USERNAME") || "guest",
     rabbitManagementPassword: getenv("CAF_RABBITMQ_MGMT_PASSWORD") || getenv("CAF_RABBITMQ_PASSWORD") || "guest",
-    memoryQueryRequestFrequency: getenv("CAF_AUTOSCALER_RABBITMQ_MEMORY_QUERY_FREQ") || 1,
+    memoryQueryRequestFrequency: getenv("CAF_AUTOSCALER_RABBITMQ_MEMORY_QUERY_FREQ") || 10,
     profiles: {
         default: {
             scalingDelay: getenv("CAF_AUTOSCALER_SCALING_DELAY") || 10,

--- a/autoscale-marathon-container/src/main/config/cfg~caf~autoscaler~RabbitWorkloadAnalyserConfiguration.js
+++ b/autoscale-marathon-container/src/main/config/cfg~caf~autoscaler~RabbitWorkloadAnalyserConfiguration.js
@@ -23,5 +23,6 @@
             scalingDelay: getenv("CAF_AUTOSCALER_SCALING_DELAY") || 10,
             backlogGoal: getenv("CAF_AUTOSCALER_BACKLOG_GOAL") || 300
         }
-    }
+    },
+    memoryQueryRequestFrequency: getenv("CAF_AUTOSCALER_RABBITMQ_MEMORY_QUERY_FREQ") || 5
 });

--- a/autoscale-marathon-container/src/main/config/cfg~caf~autoscaler~RabbitWorkloadAnalyserConfiguration.js
+++ b/autoscale-marathon-container/src/main/config/cfg~caf~autoscaler~RabbitWorkloadAnalyserConfiguration.js
@@ -18,7 +18,7 @@
             || ("http://" + (getenv("CAF_RABBITMQ_HOST") || "rabbitmq") + ":" + (getenv("CAF_RABBITMQ_MGMT_PORT") || "15672")),
     rabbitManagementUser: getenv("CAF_RABBITMQ_MGMT_USERNAME") || getenv("CAF_RABBITMQ_USERNAME") || "guest",
     rabbitManagementPassword: getenv("CAF_RABBITMQ_MGMT_PASSWORD") || getenv("CAF_RABBITMQ_PASSWORD") || "guest",
-    memoryQueryRequestFrequency: getenv("CAF_AUTOSCALER_RABBITMQ_MEMORY_QUERY_FREQ") || 5,
+    memoryQueryRequestFrequency: getenv("CAF_AUTOSCALER_RABBITMQ_MEMORY_QUERY_FREQ") || 1,
     profiles: {
         default: {
             scalingDelay: getenv("CAF_AUTOSCALER_SCALING_DELAY") || 10,

--- a/autoscale-marathon-container/src/main/config/cfg~caf~autoscaler~RabbitWorkloadAnalyserConfiguration.js
+++ b/autoscale-marathon-container/src/main/config/cfg~caf~autoscaler~RabbitWorkloadAnalyserConfiguration.js
@@ -18,11 +18,11 @@
             || ("http://" + (getenv("CAF_RABBITMQ_HOST") || "rabbitmq") + ":" + (getenv("CAF_RABBITMQ_MGMT_PORT") || "15672")),
     rabbitManagementUser: getenv("CAF_RABBITMQ_MGMT_USERNAME") || getenv("CAF_RABBITMQ_USERNAME") || "guest",
     rabbitManagementPassword: getenv("CAF_RABBITMQ_MGMT_PASSWORD") || getenv("CAF_RABBITMQ_PASSWORD") || "guest",
+    memoryQueryRequestFrequency: getenv("CAF_AUTOSCALER_RABBITMQ_MEMORY_QUERY_FREQ") || 5,
     profiles: {
         default: {
             scalingDelay: getenv("CAF_AUTOSCALER_SCALING_DELAY") || 10,
             backlogGoal: getenv("CAF_AUTOSCALER_BACKLOG_GOAL") || 300
         }
-    },
-    memoryQueryRequestFrequency: getenv("CAF_AUTOSCALER_RABBITMQ_MEMORY_QUERY_FREQ") || 5
+    }
 });

--- a/autoscale-workload-rabbit/README.md
+++ b/autoscale-workload-rabbit/README.md
@@ -25,7 +25,9 @@
  - vhost: the RabbitMQ vhost that contains the queues
  - profiles: map of profile name to `RabbitWorkloadProfile` objects, which
   represent different scaling profiles for this implementation (see below).
-  Note there *must* be a profile named "default"
+  Note there *must* be a profile named "default"  
+ - memoryQueryRequestFrequency: The number of whole minutes that the service should wait between issuing requests to check rabbitmq's
+  current memory consumption. 
 
 
 ## Usage

--- a/autoscale-workload-rabbit/README.md
+++ b/autoscale-workload-rabbit/README.md
@@ -26,7 +26,7 @@
  - profiles: map of profile name to `RabbitWorkloadProfile` objects, which
   represent different scaling profiles for this implementation (see below).
   Note there *must* be a profile named "default"  
- - memoryQueryRequestFrequency: The number of whole minutes that the service should wait between issuing requests to check rabbitmq's
+ - memoryQueryRequestFrequency: The number of seconds that the service should wait between issuing requests to check rabbitmq's
   current memory consumption. 
 
 

--- a/autoscale-workload-rabbit/src/main/java/com/hpe/caf/autoscale/workload/rabbit/RabbitSystemResourceMonitor.java
+++ b/autoscale-workload-rabbit/src/main/java/com/hpe/caf/autoscale/workload/rabbit/RabbitSystemResourceMonitor.java
@@ -24,8 +24,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Iterator;
 import java.util.concurrent.TimeUnit;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import retrofit.ErrorHandler;
 import retrofit.RestAdapter;
 import retrofit.RetrofitError;
@@ -102,7 +100,7 @@ public final class RabbitSystemResourceMonitor
         if (lastTime == 0) {
             return true;
         }
-        return (System.currentTimeMillis() - lastTime) >= (memoryQueryRequestFrequency * 60 * 1000);
+        return (System.currentTimeMillis() - lastTime) >= (memoryQueryRequestFrequency * 1000);
     }
 
     public interface RabbitManagementApi

--- a/autoscale-workload-rabbit/src/main/java/com/hpe/caf/autoscale/workload/rabbit/RabbitSystemResourceMonitor.java
+++ b/autoscale-workload-rabbit/src/main/java/com/hpe/caf/autoscale/workload/rabbit/RabbitSystemResourceMonitor.java
@@ -24,6 +24,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Iterator;
 import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import retrofit.ErrorHandler;
 import retrofit.RestAdapter;
 import retrofit.RetrofitError;
@@ -33,12 +35,15 @@ import retrofit.http.GET;
 
 public final class RabbitSystemResourceMonitor
 {
+    private volatile double memoryAllocated;
     private final RabbitManagementApi rabbitApi;
     private final String rabbitEnpoint;
     private final ObjectMapper mapper = new ObjectMapper();
     private static final int RMQ_TIMEOUT = 10;
+    private volatile long lastTime;
+    private final int memoryQueryRequestFrequency;
 
-    public RabbitSystemResourceMonitor(final String endpoint, final String user, final String pass)
+    public RabbitSystemResourceMonitor(final String endpoint, final String user, final String pass, final int memoryQueryRequestFrequency)
     {
         this.rabbitEnpoint = endpoint;
         final String credentials = user + ":" + pass;
@@ -55,26 +60,32 @@ public final class RabbitSystemResourceMonitor
         builder.setErrorHandler(new RabbitApiErrorHandler());
         final RestAdapter adapter = builder.build();
         rabbitApi = adapter.create(RabbitManagementApi.class);
+        this.lastTime = 0;
+        this.memoryQueryRequestFrequency = memoryQueryRequestFrequency;
     }
 
     public double getCurrentMemoryComsumption() throws ScalerException
     {
-        try {
-            final Response response = rabbitApi.getNodeStatus();
-            final JsonNode nodeArray = mapper.readTree(response.getBody().in());
-            final Iterator<JsonNode> iterator = nodeArray.elements();
-            double highestMemUsedInCluster = 0;
-            while (iterator.hasNext()) {
-                final JsonNode node = iterator.next();
-                final long memory_limit = node.get("mem_limit").asLong();
-                final long memory_used = node.get("mem_used").asLong();
-                final double memPercentage = ((double) memory_used / memory_limit) * 100;
-                highestMemUsedInCluster = memPercentage > highestMemUsedInCluster ? memPercentage : highestMemUsedInCluster;
+        if (shouldIssueRequest()) {
+            try {
+                final Response response = rabbitApi.getNodeStatus();
+                final JsonNode nodeArray = mapper.readTree(response.getBody().in());
+                final Iterator<JsonNode> iterator = nodeArray.elements();
+                double highestMemUsedInCluster = 0;
+                while (iterator.hasNext()) {
+                    final JsonNode node = iterator.next();
+                    final long memory_limit = node.get("mem_limit").asLong();
+                    final long memory_used = node.get("mem_used").asLong();
+                    final double memPercentage = ((double) memory_used / memory_limit) * 100;
+                    highestMemUsedInCluster = memPercentage > highestMemUsedInCluster ? memPercentage : highestMemUsedInCluster;
+                }
+                memoryAllocated =  highestMemUsedInCluster;
+                lastTime = System.currentTimeMillis();
+            } catch (final IOException ex) {
+                throw new ScalerException("Unable to map response to status request.", ex);
             }
-            return highestMemUsedInCluster;
-        } catch (final IOException ex) {
-            throw new ScalerException("Unable to map response to status request.", ex);
         }
+        return memoryAllocated;
     }
 
     private static class RabbitApiErrorHandler implements ErrorHandler
@@ -84,6 +95,14 @@ public final class RabbitSystemResourceMonitor
         {
             return new ScalerException("Failed to contact RabbitMQ management API", retrofitError);
         }
+    }
+
+    private boolean shouldIssueRequest()
+    {
+        if (lastTime == 0) {
+            return true;
+        }
+        return (System.currentTimeMillis() - lastTime) >= (memoryQueryRequestFrequency * 60 * 1000);
     }
 
     public interface RabbitManagementApi

--- a/autoscale-workload-rabbit/src/main/java/com/hpe/caf/autoscale/workload/rabbit/RabbitWorkloadAnalyserConfiguration.java
+++ b/autoscale-workload-rabbit/src/main/java/com/hpe/caf/autoscale/workload/rabbit/RabbitWorkloadAnalyserConfiguration.java
@@ -136,12 +136,12 @@ public class RabbitWorkloadAnalyserConfiguration
         this.profiles = profiles;
     }
 
-    public void setDefaultMemoryQueryTimeout(final int memoryQueryRequestFrequency)
+    public void setMemoryQueryRequestFrequency(final int memoryQueryRequestFrequency)
     {
         this.memoryQueryRequestFrequency = memoryQueryRequestFrequency;
     }
 
-    public int getDefaultMemoryQueryTimeout()
+    public int getMemoryQueryRequestFrequency()
     {
         return memoryQueryRequestFrequency;
     }

--- a/autoscale-workload-rabbit/src/main/java/com/hpe/caf/autoscale/workload/rabbit/RabbitWorkloadAnalyserConfiguration.java
+++ b/autoscale-workload-rabbit/src/main/java/com/hpe/caf/autoscale/workload/rabbit/RabbitWorkloadAnalyserConfiguration.java
@@ -71,7 +71,6 @@ public class RabbitWorkloadAnalyserConfiguration
     private Map<String, RabbitWorkloadProfile> profiles;
 
     @NotNull
-    @Size(min = 1)
     private int memoryQueryRequestFrequency;
 
 

--- a/autoscale-workload-rabbit/src/main/java/com/hpe/caf/autoscale/workload/rabbit/RabbitWorkloadAnalyserConfiguration.java
+++ b/autoscale-workload-rabbit/src/main/java/com/hpe/caf/autoscale/workload/rabbit/RabbitWorkloadAnalyserConfiguration.java
@@ -70,6 +70,10 @@ public class RabbitWorkloadAnalyserConfiguration
     @Valid
     private Map<String, RabbitWorkloadProfile> profiles;
 
+    @NotNull
+    @Size(min = 1)
+    private int memoryQueryRequestFrequency;
+
 
     public RabbitWorkloadAnalyserConfiguration() { }
 
@@ -126,10 +130,20 @@ public class RabbitWorkloadAnalyserConfiguration
     {
         return Collections.unmodifiableMap(profiles);
     }
-
+    
 
     public void setProfiles(final Map<String, RabbitWorkloadProfile> profiles)
     {
         this.profiles = profiles;
+    }
+
+    public void setDefaultMemoryQueryTimeout(final int memoryQueryRequestFrequency)
+    {
+        this.memoryQueryRequestFrequency = memoryQueryRequestFrequency;
+    }
+
+    public int getDefaultMemoryQueryTimeout()
+    {
+        return memoryQueryRequestFrequency;
     }
 }

--- a/autoscale-workload-rabbit/src/main/java/com/hpe/caf/autoscale/workload/rabbit/RabbitWorkloadAnalyserConfiguration.java
+++ b/autoscale-workload-rabbit/src/main/java/com/hpe/caf/autoscale/workload/rabbit/RabbitWorkloadAnalyserConfiguration.java
@@ -129,7 +129,7 @@ public class RabbitWorkloadAnalyserConfiguration
     {
         return Collections.unmodifiableMap(profiles);
     }
-    
+
 
     public void setProfiles(final Map<String, RabbitWorkloadProfile> profiles)
     {

--- a/autoscale-workload-rabbit/src/main/java/com/hpe/caf/autoscale/workload/rabbit/RabbitWorkloadAnalyserFactory.java
+++ b/autoscale-workload-rabbit/src/main/java/com/hpe/caf/autoscale/workload/rabbit/RabbitWorkloadAnalyserFactory.java
@@ -49,7 +49,7 @@ public class RabbitWorkloadAnalyserFactory implements WorkloadAnalyserFactory
         this.provider = new RabbitStatsReporter(config.getRabbitManagementEndpoint(), config.getRabbitManagementUser(),
                                                         config.getRabbitManagementPassword(), config.getVhost());
         this.memoryMonitor = new RabbitSystemResourceMonitor(config.getRabbitManagementEndpoint(), config.getRabbitManagementUser(),
-                                                        config.getRabbitManagementPassword(), config.getDefaultMemoryQueryTimeout());
+                                                        config.getRabbitManagementPassword(), config.getMemoryQueryRequestFrequency());
         this.defaultProfile = config.getProfiles().get(RabbitWorkloadAnalyserConfiguration.DEFAULT_PROFILE_NAME);
     }
 

--- a/autoscale-workload-rabbit/src/main/java/com/hpe/caf/autoscale/workload/rabbit/RabbitWorkloadAnalyserFactory.java
+++ b/autoscale-workload-rabbit/src/main/java/com/hpe/caf/autoscale/workload/rabbit/RabbitWorkloadAnalyserFactory.java
@@ -49,7 +49,7 @@ public class RabbitWorkloadAnalyserFactory implements WorkloadAnalyserFactory
         this.provider = new RabbitStatsReporter(config.getRabbitManagementEndpoint(), config.getRabbitManagementUser(),
                                                         config.getRabbitManagementPassword(), config.getVhost());
         this.memoryMonitor = new RabbitSystemResourceMonitor(config.getRabbitManagementEndpoint(), config.getRabbitManagementUser(),
-                                                        config.getRabbitManagementPassword());
+                                                        config.getRabbitManagementPassword(), config.getDefaultMemoryQueryTimeout());
         this.defaultProfile = config.getProfiles().get(RabbitWorkloadAnalyserConfiguration.DEFAULT_PROFILE_NAME);
     }
 


### PR DESCRIPTION
https://portal.digitalsafe.net/browse/SCMOD-8421

This PR allows the Autoscaler to continue scaling even after the service has started to take emergency actions to protect RabbitMQ. This PR also adds configuration to the RabbitMQ memory usage querying to prevent multiple queries being issued to RabbitMQ within milliseconds of each other.
**BUILD**: http://sou-jenkins2.swinfra.net/job/Autoscaler/view/Developer/job/Autoscaler~autoscaler~anthony~CI/