### PR TITLE
SCMOD-10780: Fix healthcheck failure when a rabbit node goes down

### DIFF
--- a/autoscale-acceptance-tests/pom.xml
+++ b/autoscale-acceptance-tests/pom.xml
@@ -231,9 +231,9 @@
                                 <env>
                                     <DOCKER_HOST>http://${docker.host.address}:2375</DOCKER_HOST>
                                     <CAF_AUTOSCALER_DOCKER_SWARM_STACK>autoscalerdemo</CAF_AUTOSCALER_DOCKER_SWARM_STACK>
-                                    <CAF_RABBITMQ_MGMT_URL>http://rabbitmq:5672</CAF_RABBITMQ_MGMT_URL>
-                                    <!--<CAF_RABBITMQ_MGMT_USERNAME>guest</CAF_RABBITMQ_MGMT_USERNAME>
-                                    <CAF_RABBITMQ_MGMT_PASSWORD>guest</CAF_RABBITMQ_MGMT_PASSWORD>-->
+                                    <CAF_RABBITMQ_MGMT_URL>http://rabbitmq:15672</CAF_RABBITMQ_MGMT_URL>
+                                    <CAF_RABBITMQ_MGMT_USERNAME>guest</CAF_RABBITMQ_MGMT_USERNAME>
+                                    <CAF_RABBITMQ_MGMT_PASSWORD>guest</CAF_RABBITMQ_MGMT_PASSWORD>
                                 </env>
                                 <links>
                                     <link>marathon</link>
@@ -269,8 +269,8 @@
                                     <CAF_AUTOSCALER_SMTP_PORT>testPort</CAF_AUTOSCALER_SMTP_PORT>
                                     <CAF_AUTOSCALER_SMTP_EMAIL_ADDRESS_TO>noone@nothing.com</CAF_AUTOSCALER_SMTP_EMAIL_ADDRESS_TO>
                                     <CAF_AUTOSCALER_ALERT_DISABLED>true</CAF_AUTOSCALER_ALERT_DISABLED>
-<!--                                    <CAF_RABBITMQ_MGMT_USERNAME>guest</CAF_RABBITMQ_MGMT_USERNAME>
-                                    <CAF_RABBITMQ_MGMT_PASSWORD>guest</CAF_RABBITMQ_MGMT_PASSWORD>-->
+                                    <CAF_RABBITMQ_MGMT_USERNAME>guest</CAF_RABBITMQ_MGMT_USERNAME>
+                                    <CAF_RABBITMQ_MGMT_PASSWORD>guest</CAF_RABBITMQ_MGMT_PASSWORD>
                                 </env>
                                 <links>
                                     <link>marathon</link>

--- a/autoscale-workload-rabbit/src/main/java/com/hpe/caf/autoscale/workload/rabbit/RabbitManagementApiFactory.java
+++ b/autoscale-workload-rabbit/src/main/java/com/hpe/caf/autoscale/workload/rabbit/RabbitManagementApiFactory.java
@@ -46,10 +46,9 @@ final class RabbitManagementApiFactory
             requestFacade.addHeader("Accept", "application/json");
             requestFacade.addHeader("Authorization", authorizationHeaderValue);
         });
-
         restAdapterBuilder.setErrorHandler(new RabbitApiErrorHandler());
-        final RestAdapter adapter = restAdapterBuilder.build();
-        return adapter.create(RabbitManagementApi.class);
+        final RestAdapter restAdapter = restAdapterBuilder.build();
+        return restAdapter.create(RabbitManagementApi.class);
     }
 
     private RabbitManagementApiFactory()
@@ -68,6 +67,6 @@ final class RabbitManagementApiFactory
     public interface RabbitManagementApi
     {
         @GET("/api/nodes/")
-        Response getNodeStatus();
+        Response getNodeStatus() throws ScalerException;
     }
 }

--- a/autoscale-workload-rabbit/src/main/java/com/hpe/caf/autoscale/workload/rabbit/RabbitManagementApiFactory.java
+++ b/autoscale-workload-rabbit/src/main/java/com/hpe/caf/autoscale/workload/rabbit/RabbitManagementApiFactory.java
@@ -27,13 +27,12 @@ import retrofit.client.OkClient;
 import retrofit.client.Response;
 import retrofit.http.GET;
 
-final class RabbitManagementApiWrapper
+final class RabbitManagementApiFactory
 {
     private static final int READ_TIMEOUT_SECONDS = 10;
     private static final int CONNECT_TIMEOUT_SECONDS = 10;
-    private final RabbitManagementApi rabbitManagementApi;
 
-    RabbitManagementApiWrapper(final String endpoint, final String user, final String password)
+    public static RabbitManagementApi create(final String endpoint, final String user, final String password)
     {
         final OkHttpClient okHttpClient = new OkHttpClient();
         okHttpClient.setReadTimeout(READ_TIMEOUT_SECONDS, TimeUnit.SECONDS);
@@ -50,7 +49,11 @@ final class RabbitManagementApiWrapper
 
         restAdapterBuilder.setErrorHandler(new RabbitApiErrorHandler());
         final RestAdapter adapter = restAdapterBuilder.build();
-        this.rabbitManagementApi = adapter.create(RabbitManagementApi.class);
+        return adapter.create(RabbitManagementApi.class);
+    }
+
+    private RabbitManagementApiFactory()
+    {
     }
 
     private static class RabbitApiErrorHandler implements ErrorHandler
@@ -66,10 +69,5 @@ final class RabbitManagementApiWrapper
     {
         @GET("/api/nodes/")
         Response getNodeStatus();
-    }
-
-    public RabbitManagementApi getRabbitManagementApi()
-    {
-        return rabbitManagementApi;
     }
 }

--- a/autoscale-workload-rabbit/src/main/java/com/hpe/caf/autoscale/workload/rabbit/RabbitManagementApiWrapper.java
+++ b/autoscale-workload-rabbit/src/main/java/com/hpe/caf/autoscale/workload/rabbit/RabbitManagementApiWrapper.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2015-2020 Micro Focus or one of its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hpe.caf.autoscale.workload.rabbit;
+
+import com.hpe.caf.api.autoscale.ScalerException;
+import com.squareup.okhttp.OkHttpClient;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import retrofit.ErrorHandler;
+import retrofit.RestAdapter;
+import retrofit.RetrofitError;
+import retrofit.client.OkClient;
+import retrofit.client.Response;
+import retrofit.http.GET;
+
+final class RabbitManagementApiWrapper
+{
+    private static final int READ_TIMEOUT_SECONDS = 10;
+    private static final int CONNECT_TIMEOUT_SECONDS = 10;
+    private final RabbitManagementApi rabbitManagementApi;
+
+    RabbitManagementApiWrapper(final String endpoint, final String user, final String password)
+    {
+        final OkHttpClient okHttpClient = new OkHttpClient();
+        okHttpClient.setReadTimeout(READ_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        okHttpClient.setConnectTimeout(CONNECT_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        final RestAdapter.Builder restAdapterBuilder
+            = new RestAdapter.Builder().setEndpoint(endpoint).setClient(new OkClient(okHttpClient));
+        restAdapterBuilder.setRequestInterceptor(requestFacade -> {
+            final String credentials = user + ":" + password;
+            final String authorizationHeaderValue
+                = "Basic " + Base64.getEncoder().encodeToString(credentials.getBytes(StandardCharsets.UTF_8));
+            requestFacade.addHeader("Accept", "application/json");
+            requestFacade.addHeader("Authorization", authorizationHeaderValue);
+        });
+
+        restAdapterBuilder.setErrorHandler(new RabbitApiErrorHandler());
+        final RestAdapter adapter = restAdapterBuilder.build();
+        this.rabbitManagementApi = adapter.create(RabbitManagementApi.class);
+    }
+
+    private static class RabbitApiErrorHandler implements ErrorHandler
+    {
+        @Override
+        public Throwable handleError(final RetrofitError retrofitError)
+        {
+            return new ScalerException("Failed to contact RabbitMQ management API", retrofitError);
+        }
+    }
+
+    public interface RabbitManagementApi
+    {
+        @GET("/api/nodes/")
+        Response getNodeStatus();
+    }
+
+    public RabbitManagementApi getRabbitManagementApi()
+    {
+        return rabbitManagementApi;
+    }
+}

--- a/autoscale-workload-rabbit/src/main/java/com/hpe/caf/autoscale/workload/rabbit/RabbitManagementApiWrapper.java
+++ b/autoscale-workload-rabbit/src/main/java/com/hpe/caf/autoscale/workload/rabbit/RabbitManagementApiWrapper.java
@@ -20,8 +20,6 @@ import com.squareup.okhttp.OkHttpClient;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.concurrent.TimeUnit;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import retrofit.ErrorHandler;
 import retrofit.RestAdapter;
 import retrofit.RetrofitError;

--- a/autoscale-workload-rabbit/src/main/java/com/hpe/caf/autoscale/workload/rabbit/RabbitSystemResourceMonitor.java
+++ b/autoscale-workload-rabbit/src/main/java/com/hpe/caf/autoscale/workload/rabbit/RabbitSystemResourceMonitor.java
@@ -18,7 +18,7 @@ package com.hpe.caf.autoscale.workload.rabbit;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hpe.caf.api.autoscale.ScalerException;
-import com.hpe.caf.autoscale.workload.rabbit.RabbitManagementApiWrapper.RabbitManagementApi;
+import com.hpe.caf.autoscale.workload.rabbit.RabbitManagementApiFactory.RabbitManagementApi;
 import java.io.IOException;
 import java.util.Iterator;
 import retrofit.client.Response;

--- a/autoscale-workload-rabbit/src/main/java/com/hpe/caf/autoscale/workload/rabbit/RabbitSystemResourceMonitor.java
+++ b/autoscale-workload-rabbit/src/main/java/com/hpe/caf/autoscale/workload/rabbit/RabbitSystemResourceMonitor.java
@@ -18,46 +18,23 @@ package com.hpe.caf.autoscale.workload.rabbit;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hpe.caf.api.autoscale.ScalerException;
-import com.squareup.okhttp.OkHttpClient;
+import com.hpe.caf.autoscale.workload.rabbit.RabbitManagementApiWrapper.RabbitManagementApi;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.util.Base64;
 import java.util.Iterator;
-import java.util.concurrent.TimeUnit;
-import retrofit.ErrorHandler;
-import retrofit.RestAdapter;
-import retrofit.RetrofitError;
-import retrofit.client.OkClient;
 import retrofit.client.Response;
-import retrofit.http.GET;
 
 public final class RabbitSystemResourceMonitor
 {
     private volatile double memoryAllocated;
-    private final RabbitManagementApi rabbitApi;
-    private final String rabbitEnpoint;
+    private final RabbitManagementApi rabbitManagementApi;
     private final ObjectMapper mapper = new ObjectMapper();
-    private static final int RMQ_TIMEOUT = 10;
     private volatile long lastTime;
     private final int memoryQueryRequestFrequency;
 
-    public RabbitSystemResourceMonitor(final String endpoint, final String user, final String pass, final int memoryQueryRequestFrequency)
+    public RabbitSystemResourceMonitor(final RabbitManagementApi rabbitManagementApi,
+                                       final int memoryQueryRequestFrequency)
     {
-        this.rabbitEnpoint = endpoint;
-        final String credentials = user + ":" + pass;
-        final OkHttpClient ok = new OkHttpClient();
-        ok.setReadTimeout(RMQ_TIMEOUT, TimeUnit.SECONDS);
-        ok.setConnectTimeout(RMQ_TIMEOUT, TimeUnit.SECONDS);
-        // build up a RestAdapter that will automatically handle authentication for us
-        final RestAdapter.Builder builder = new RestAdapter.Builder().setEndpoint(endpoint).setClient(new OkClient(ok));
-        builder.setRequestInterceptor(requestFacade -> {
-            final String str = "Basic " + Base64.getEncoder().encodeToString(credentials.getBytes(StandardCharsets.UTF_8));
-            requestFacade.addHeader("Accept", "application/json");
-            requestFacade.addHeader("Authorization", str);
-        });
-        builder.setErrorHandler(new RabbitApiErrorHandler());
-        final RestAdapter adapter = builder.build();
-        rabbitApi = adapter.create(RabbitManagementApi.class);
+        this.rabbitManagementApi = rabbitManagementApi;
         this.lastTime = 0;
         this.memoryQueryRequestFrequency = memoryQueryRequestFrequency;
     }
@@ -66,7 +43,7 @@ public final class RabbitSystemResourceMonitor
     {
         if (shouldIssueRequest()) {
             try {
-                final Response response = rabbitApi.getNodeStatus();
+                final Response response = rabbitManagementApi.getNodeStatus();
                 final JsonNode nodeArray = mapper.readTree(response.getBody().in());
                 final Iterator<JsonNode> iterator = nodeArray.elements();
                 double highestMemUsedInCluster = 0;
@@ -90,27 +67,11 @@ public final class RabbitSystemResourceMonitor
         return memoryAllocated;
     }
 
-    private static class RabbitApiErrorHandler implements ErrorHandler
-    {
-        @Override
-        public Throwable handleError(final RetrofitError retrofitError)
-        {
-            return new ScalerException("Failed to contact RabbitMQ management API", retrofitError);
-        }
-    }
-
     private boolean shouldIssueRequest()
     {
         if (lastTime == 0) {
             return true;
         }
         return (System.currentTimeMillis() - lastTime) >= (memoryQueryRequestFrequency * 1000);
-    }
-
-    public interface RabbitManagementApi
-    {
-        @GET("/api/nodes/")
-        Response getNodeStatus()
-            throws ScalerException;
     }
 }

--- a/autoscale-workload-rabbit/src/main/java/com/hpe/caf/autoscale/workload/rabbit/RabbitWorkloadAnalyserFactory.java
+++ b/autoscale-workload-rabbit/src/main/java/com/hpe/caf/autoscale/workload/rabbit/RabbitWorkloadAnalyserFactory.java
@@ -16,43 +16,50 @@
 package com.hpe.caf.autoscale.workload.rabbit;
 
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hpe.caf.api.HealthResult;
 import com.hpe.caf.api.HealthStatus;
 import com.hpe.caf.api.autoscale.WorkloadAnalyser;
 import com.hpe.caf.api.autoscale.WorkloadAnalyserFactory;
+import com.hpe.caf.autoscale.workload.rabbit.RabbitManagementApiWrapper.RabbitManagementApi;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.net.InetSocketAddress;
-import java.net.MalformedURLException;
-import java.net.Socket;
-import java.net.URL;
+import java.util.Iterator;
 import java.util.Objects;
-
+import retrofit.client.Response;
 
 public class RabbitWorkloadAnalyserFactory implements WorkloadAnalyserFactory
 {
     private final RabbitWorkloadAnalyserConfiguration config;
     private final RabbitStatsReporter provider;
+    private final RabbitManagementApi rabbitManagementApi;
     private final RabbitSystemResourceMonitor memoryMonitor;
-    private final URL url;
     private final RabbitWorkloadProfile defaultProfile;
+    private final ObjectMapper objectMapper;
+    private final String nodeStatusEndpoint;
     private static final Logger LOG = LoggerFactory.getLogger(RabbitWorkloadAnalyserFactory.class);
 
-
     public RabbitWorkloadAnalyserFactory(final RabbitWorkloadAnalyserConfiguration config)
-            throws MalformedURLException
     {
         this.config = Objects.requireNonNull(config);
-        this.url = new URL(config.getRabbitManagementEndpoint());
-        this.provider = new RabbitStatsReporter(config.getRabbitManagementEndpoint(), config.getRabbitManagementUser(),
-                                                        config.getRabbitManagementPassword(), config.getVhost());
-        this.memoryMonitor = new RabbitSystemResourceMonitor(config.getRabbitManagementEndpoint(), config.getRabbitManagementUser(),
-                                                        config.getRabbitManagementPassword(), config.getMemoryQueryRequestFrequency());
+        this.provider = new RabbitStatsReporter(
+            config.getRabbitManagementEndpoint(),
+            config.getRabbitManagementUser(),
+            config.getRabbitManagementPassword(),
+            config.getVhost());
+        this.rabbitManagementApi = new RabbitManagementApiWrapper(
+            config.getRabbitManagementEndpoint(),
+            config.getRabbitManagementUser(),
+            config.getRabbitManagementPassword())
+            .getRabbitManagementApi();
+        this.memoryMonitor = new RabbitSystemResourceMonitor(rabbitManagementApi, config.getMemoryQueryRequestFrequency());
         this.defaultProfile = config.getProfiles().get(RabbitWorkloadAnalyserConfiguration.DEFAULT_PROFILE_NAME);
+        this.objectMapper = new ObjectMapper();
+        this.nodeStatusEndpoint = config.getRabbitManagementEndpoint() + "/api/nodes/";
     }
-
 
     @Override
     public WorkloadAnalyser getAnalyser(final String scalingTarget, final String scalingProfile)
@@ -66,16 +73,39 @@ public class RabbitWorkloadAnalyserFactory implements WorkloadAnalyserFactory
         return new RabbitWorkloadAnalyser(scalingTarget, provider, profile, memoryMonitor);
     }
 
-
     @Override
     public HealthResult healthCheck()
     {
-        try ( Socket socket = new Socket()) {
-            socket.connect(new InetSocketAddress(url.getHost(), url.getPort()), 5000);
-            return HealthResult.RESULT_HEALTHY;
-        } catch (IOException e) {
-            LOG.warn("Connection failure to HTTP endpoint", e);
-            return new HealthResult(HealthStatus.UNHEALTHY, "Cannot connect to REST endpoint: " + url);
+        // TODO TEMP: Remove (rory)
+        LOG.info("TEMP LOG: In healthcheck: " + config.getRabbitManagementEndpoint() + " " + config.getRabbitManagementUser() + " " + config.getRabbitManagementPassword());
+        try {
+            if (atLeastOneNodeRunning()) {
+                return HealthResult.RESULT_HEALTHY;
+            } else {
+                final String message
+                    = "At least 1 RabbitMQ node must be running, found 0 after checking " + nodeStatusEndpoint;
+                LOG.warn(message);
+                return new HealthResult(HealthStatus.UNHEALTHY, message);
+            }
+        } catch (final IOException e) {
+            final String message = "IOException when trying to query " + nodeStatusEndpoint + " during healthcheck";
+            LOG.warn(message, e);
+            return new HealthResult(HealthStatus.UNHEALTHY, message);
         }
+    }
+
+    private boolean atLeastOneNodeRunning() throws IOException
+    {
+        final Response nodeStatusResponse = rabbitManagementApi.getNodeStatus();
+        final JsonNode nodeArray = objectMapper.readTree(nodeStatusResponse.getBody().in());
+        final Iterator<JsonNode> iterator = nodeArray.elements();
+        while (iterator.hasNext()) {
+            final JsonNode jsonNode = iterator.next();
+            final JsonNode runningJsonNode = jsonNode.get("running");
+            if (runningJsonNode != null && runningJsonNode.asBoolean()) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/autoscale-workload-rabbit/src/main/java/com/hpe/caf/autoscale/workload/rabbit/RabbitWorkloadAnalyserFactory.java
+++ b/autoscale-workload-rabbit/src/main/java/com/hpe/caf/autoscale/workload/rabbit/RabbitWorkloadAnalyserFactory.java
@@ -22,7 +22,7 @@ import com.hpe.caf.api.HealthResult;
 import com.hpe.caf.api.HealthStatus;
 import com.hpe.caf.api.autoscale.WorkloadAnalyser;
 import com.hpe.caf.api.autoscale.WorkloadAnalyserFactory;
-import com.hpe.caf.autoscale.workload.rabbit.RabbitManagementApiWrapper.RabbitManagementApi;
+import com.hpe.caf.autoscale.workload.rabbit.RabbitManagementApiFactory.RabbitManagementApi;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -50,11 +50,10 @@ public class RabbitWorkloadAnalyserFactory implements WorkloadAnalyserFactory
             config.getRabbitManagementUser(),
             config.getRabbitManagementPassword(),
             config.getVhost());
-        this.rabbitManagementApi = new RabbitManagementApiWrapper(
+        this.rabbitManagementApi = RabbitManagementApiFactory.create(
             config.getRabbitManagementEndpoint(),
             config.getRabbitManagementUser(),
-            config.getRabbitManagementPassword())
-            .getRabbitManagementApi();
+            config.getRabbitManagementPassword());
         this.memoryMonitor = new RabbitSystemResourceMonitor(rabbitManagementApi, config.getMemoryQueryRequestFrequency());
         this.defaultProfile = config.getProfiles().get(RabbitWorkloadAnalyserConfiguration.DEFAULT_PROFILE_NAME);
         this.objectMapper = new ObjectMapper();

--- a/autoscale-workload-rabbit/src/main/java/com/hpe/caf/autoscale/workload/rabbit/RabbitWorkloadAnalyserFactory.java
+++ b/autoscale-workload-rabbit/src/main/java/com/hpe/caf/autoscale/workload/rabbit/RabbitWorkloadAnalyserFactory.java
@@ -76,8 +76,6 @@ public class RabbitWorkloadAnalyserFactory implements WorkloadAnalyserFactory
     @Override
     public HealthResult healthCheck()
     {
-        // TODO TEMP: Remove (rory)
-        LOG.info("TEMP LOG: In healthcheck: " + config.getRabbitManagementEndpoint() + " " + config.getRabbitManagementUser() + " " + config.getRabbitManagementPassword());
         try {
             if (atLeastOneNodeRunning()) {
                 return HealthResult.RESULT_HEALTHY;

--- a/autoscale-workload-rabbit/src/main/java/com/hpe/caf/autoscale/workload/rabbit/RabbitWorkloadAnalyserFactoryProvider.java
+++ b/autoscale-workload-rabbit/src/main/java/com/hpe/caf/autoscale/workload/rabbit/RabbitWorkloadAnalyserFactoryProvider.java
@@ -22,9 +22,6 @@ import com.hpe.caf.api.autoscale.ScalerException;
 import com.hpe.caf.api.autoscale.WorkloadAnalyserFactory;
 import com.hpe.caf.api.autoscale.WorkloadAnalyserFactoryProvider;
 
-import java.net.MalformedURLException;
-
-
 public class RabbitWorkloadAnalyserFactoryProvider implements WorkloadAnalyserFactoryProvider
 {
     @Override
@@ -33,11 +30,10 @@ public class RabbitWorkloadAnalyserFactoryProvider implements WorkloadAnalyserFa
     {
         try {
             return new RabbitWorkloadAnalyserFactory(configurationSource.getConfiguration(RabbitWorkloadAnalyserConfiguration.class));
-        } catch (ConfigurationException | MalformedURLException e) {
+        } catch (ConfigurationException e) {
             throw new ScalerException("Failed to create a workload analyser factory", e);
         }
     }
-
 
     @Override
     public String getWorkloadAnalyserName()


### PR DESCRIPTION
Jira: https://portal.digitalsafe.net/browse/SCMOD-10780

On eval, which is running a 3-node rabbit cluster, it was noticed that when 1 rabbit node is down, the healthcheck starts failing, and doesn't seem to recover (healthcheck continues to fail even after all messages and queues had been moved from the faulty node). Although the healthcheck failed, the calls made to the Rabbit API by the autoscaler continue to work.

The Rabbit API calls used by the autoscaler use the retrofit library to perform the calls,  while the healthcheck just uses a plain Java Socket to test if it can get a connection.

There is something happening when using the socket approach that results in the call failing - maybe some caching at some level is causing the call to get routed to a dead node?

Since the API calls are working fine, whereas the socket approach is not, this fix changes the healthcheck so that it uses the retrofit library to make the http://rabbitmq.eval.aspenaws.local:15672 call instead of creating a new Socket.

I have tested this on Baltra by taking down one or more node(s) in the cluster and verifying that the healthcheck now only fails when *all* the nodes in the cluster are down.