### PR TITLE
SCMOD-13115:Edit log warning message to something more readable.

### DIFF
--- a/autoscale-api/src/main/java/com/github/autoscaler/api/QueueNotFoundException.java
+++ b/autoscale-api/src/main/java/com/github/autoscaler/api/QueueNotFoundException.java
@@ -1,0 +1,11 @@
+package com.github.autoscaler.api;
+
+/**
+ * Thrown by the autoscaler application or components when a Queue is not found.
+ */
+public class QueueNotFoundException extends ScalerException{
+
+    public QueueNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/autoscale-api/src/main/java/com/github/autoscaler/api/QueueNotFoundException.java
+++ b/autoscale-api/src/main/java/com/github/autoscaler/api/QueueNotFoundException.java
@@ -18,10 +18,10 @@ package com.github.autoscaler.api;
 /**
  * Thrown by the autoscaler application or components when a Queue is not found.
  */
-public final class QueueNotFoundException extends ScalerException{
-
+public final class QueueNotFoundException extends ScalerException
+{
     public QueueNotFoundException(final String url)
     {
-        super("Queue not found in" + url);
+        super("Queue not found: " + url);
     }
 }

--- a/autoscale-api/src/main/java/com/github/autoscaler/api/QueueNotFoundException.java
+++ b/autoscale-api/src/main/java/com/github/autoscaler/api/QueueNotFoundException.java
@@ -1,11 +1,27 @@
+/*
+ * Copyright 2015-2021 Micro Focus or one of its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.github.autoscaler.api;
 
 /**
  * Thrown by the autoscaler application or components when a Queue is not found.
  */
-public class QueueNotFoundException extends ScalerException{
+public final class QueueNotFoundException extends ScalerException{
 
-    public QueueNotFoundException(String message) {
-        super(message);
+    public QueueNotFoundException(final String url)
+    {
+        super("Queue not found in" + url);
     }
 }

--- a/autoscale-core/src/main/java/com/github/autoscaler/core/ScalerThread.java
+++ b/autoscale-core/src/main/java/com/github/autoscaler/core/ScalerThread.java
@@ -15,12 +15,8 @@
  */
 package com.github.autoscaler.core;
 
-import com.github.autoscaler.api.InstanceInfo;
-import com.github.autoscaler.api.ScalerException;
-import com.github.autoscaler.api.ScalingAction;
-import com.github.autoscaler.api.ScalingOperation;
-import com.github.autoscaler.api.ServiceScaler;
-import com.github.autoscaler.api.WorkloadAnalyser;
+import com.github.autoscaler.api.*;
+
 import java.text.DecimalFormat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -157,10 +153,10 @@ public class ScalerThread implements Runnable
                 default:
                     break;
             }
+        }catch (QueueNotFoundException e) {
+            LOG.warn("Queue not found exception {}", serviceRef, e);
         } catch (ScalerException e) {
-            int start = e.toString().indexOf("Failed");
-            int end = e.toString().indexOf("retry.");
-            LOG.warn("Failed analysis run for service {}", serviceRef, e.toString().substring(start, end) + "retry.");
+            LOG.warn("Failed analysis run for service {}", serviceRef, e);
         } catch (final RuntimeException e) {
             // library methods have been known to throw RuntimeException when there's no programming
             // error - but if we throw, we won't be scheduled to run again, so we must catch and

--- a/autoscale-core/src/main/java/com/github/autoscaler/core/ScalerThread.java
+++ b/autoscale-core/src/main/java/com/github/autoscaler/core/ScalerThread.java
@@ -15,9 +15,16 @@
  */
 package com.github.autoscaler.core;
 
-import com.github.autoscaler.api.*;
 
 import java.text.DecimalFormat;
+
+import com.github.autoscaler.api.InstanceInfo;
+import com.github.autoscaler.api.ScalingOperation;
+import com.github.autoscaler.api.ServiceScaler;
+import com.github.autoscaler.api.WorkloadAnalyser;
+import com.github.autoscaler.api.ScalingAction;
+import com.github.autoscaler.api.ScalerException;
+import com.github.autoscaler.api.QueueNotFoundException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -153,9 +160,9 @@ public class ScalerThread implements Runnable
                 default:
                     break;
             }
-        }catch (QueueNotFoundException e) {
-            LOG.warn("Queue not found exception {}", serviceRef, e);
-        } catch (ScalerException e) {
+        }catch (final QueueNotFoundException e) {
+            LOG.warn("Queue not found {}", serviceRef);
+        } catch (final ScalerException e) {
             LOG.warn("Failed analysis run for service {}", serviceRef, e);
         } catch (final RuntimeException e) {
             // library methods have been known to throw RuntimeException when there's no programming

--- a/autoscale-core/src/main/java/com/github/autoscaler/core/ScalerThread.java
+++ b/autoscale-core/src/main/java/com/github/autoscaler/core/ScalerThread.java
@@ -15,16 +15,14 @@
  */
 package com.github.autoscaler.core;
 
-
-import java.text.DecimalFormat;
-
 import com.github.autoscaler.api.InstanceInfo;
+import com.github.autoscaler.api.QueueNotFoundException;
+import com.github.autoscaler.api.ScalerException;
+import com.github.autoscaler.api.ScalingAction;
 import com.github.autoscaler.api.ScalingOperation;
 import com.github.autoscaler.api.ServiceScaler;
 import com.github.autoscaler.api.WorkloadAnalyser;
-import com.github.autoscaler.api.ScalingAction;
-import com.github.autoscaler.api.ScalerException;
-import com.github.autoscaler.api.QueueNotFoundException;
+import java.text.DecimalFormat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -160,9 +158,9 @@ public class ScalerThread implements Runnable
                 default:
                     break;
             }
-        }catch (final QueueNotFoundException e) {
+        } catch (final QueueNotFoundException e) {
             LOG.warn("Queue not found {}", serviceRef);
-        } catch (final ScalerException e) {
+        } catch (ScalerException e) {
             LOG.warn("Failed analysis run for service {}", serviceRef, e);
         } catch (final RuntimeException e) {
             // library methods have been known to throw RuntimeException when there's no programming

--- a/autoscale-core/src/main/java/com/github/autoscaler/core/ScalerThread.java
+++ b/autoscale-core/src/main/java/com/github/autoscaler/core/ScalerThread.java
@@ -158,7 +158,9 @@ public class ScalerThread implements Runnable
                     break;
             }
         } catch (ScalerException e) {
-            LOG.warn("Failed analysis run for service {}", serviceRef, e);
+            int start = e.toString().indexOf("Failed");
+            int end = e.toString().indexOf("retry.");
+            LOG.warn("Failed analysis run for service {}", serviceRef, e.toString().substring(start, end) + "retry.");
         } catch (final RuntimeException e) {
             // library methods have been known to throw RuntimeException when there's no programming
             // error - but if we throw, we won't be scheduled to run again, so we must catch and

--- a/autoscale-workload-rabbit/src/main/java/com/github/autoscaler/workload/rabbit/RabbitStatsReporter.java
+++ b/autoscale-workload-rabbit/src/main/java/com/github/autoscaler/workload/rabbit/RabbitStatsReporter.java
@@ -18,6 +18,7 @@ package com.github.autoscaler.workload.rabbit;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.autoscaler.api.QueueNotFoundException;
 import com.github.autoscaler.api.ScalerException;
 import com.squareup.okhttp.OkHttpClient;
 import retrofit.ErrorHandler;
@@ -118,6 +119,10 @@ public class RabbitStatsReporter
         @Override
         public Throwable handleError(final RetrofitError retrofitError)
         {
+            if (retrofitError.getResponse().getStatus() == 404) {
+                return new QueueNotFoundException("Queue instance cannot be be zero "  + retrofitError.getUrl());
+            }
+
             return new ScalerException("Failed to contact RabbitMQ management API using url " + retrofitError.getUrl() 
                 + ". Queue may not yet have been created or RabbitMQ could be unavailable, will retry.", retrofitError);
         }

--- a/autoscale-workload-rabbit/src/main/java/com/github/autoscaler/workload/rabbit/RabbitStatsReporter.java
+++ b/autoscale-workload-rabbit/src/main/java/com/github/autoscaler/workload/rabbit/RabbitStatsReporter.java
@@ -120,7 +120,7 @@ public class RabbitStatsReporter
         public Throwable handleError(final RetrofitError retrofitError)
         {
             if (retrofitError.getResponse().getStatus() == 404) {
-                return new QueueNotFoundException("Queue instance cannot be be zero "  + retrofitError.getUrl());
+                return new QueueNotFoundException(retrofitError.getUrl());
             }
 
             return new ScalerException("Failed to contact RabbitMQ management API using url " + retrofitError.getUrl() 


### PR DESCRIPTION
In reference to => https://portal.digitalsafe.net/browse/SCMOD-13115.
Removing a lot of unnecessary content from the log message.

Log message in the ticket would be reduced to => "Failed analysis run for service /managed-queue-workers/appresources-worker, Failed to contact RabbitMQ management API using url http://larry-cent01.aspensb.local:15672/api/queues/%2F/appresources-worker-in. Queue may not yet have been created or RabbitMQ could be unavailable, will retry." 