### PR TITLE
US-539028: Update to latest java base image

### DIFF
--- a/autoscale-dockerswarm-container/pom.xml
+++ b/autoscale-dockerswarm-container/pom.xml
@@ -106,7 +106,7 @@
                             <alias>autoscale-container</alias>
                             <name>${dockerAutoscalerOrg}autoscale-dockerswarm-rabbit${dockerProjectVersion}</name>
                             <build>
-                                <from>${dockerHubPublic}/cafapi/opensuse-jre11:3</from>
+                                <from>${dockerHubPublic}/cafapi/prereleases:opensuse-jre11-3.6.0-SNAPSHOT</from>
                                 <!-- The entry point will be the worker.sh executable. -->
                                 <cmd>
                                     <exec>

--- a/autoscale-kubernetes-container/pom.xml
+++ b/autoscale-kubernetes-container/pom.xml
@@ -153,7 +153,7 @@
                             <alias>autoscale-container</alias>
                             <name>${dockerAutoscalerOrg}autoscale-kubernetes-rabbit${dockerProjectVersion}</name>
                             <build>
-                                <from>${dockerHubPublic}/cafapi/opensuse-jre11:3</from>
+                                <from>${dockerHubPublic}/cafapi/prereleases:opensuse-jre11-3.6.0-SNAPSHOT</from>
                                 <cmd>
                                     <exec>
                                         <args>/maven/scaler.sh</args>

--- a/autoscale-marathon-container/pom.xml
+++ b/autoscale-marathon-container/pom.xml
@@ -143,7 +143,7 @@
                             <alias>autoscale-container</alias>
                             <name>${dockerAutoscalerOrg}autoscale-marathon-rabbit${dockerProjectVersion}</name>
                             <build>
-                                <from>${dockerHubPublic}/cafapi/opensuse-jre11:3</from>
+                                <from>${dockerHubPublic}/cafapi/prereleases:opensuse-jre11-3.6.0-SNAPSHOT</from>
                                 <!-- The entry point will be the worker.sh executable. -->
                                 <cmd>
                                     <exec>


### PR DESCRIPTION
'opensuse-jre11:3' opensuse version replaced by 'prereleases:opensuse-jre11-3.6.0-SNAPSHOT'