### PR TITLE
Delete sepg-release-info

### DIFF
--- a/.sepg-release-info/artifacts/open-source/docker-images.yaml
+++ b/.sepg-release-info/artifacts/open-source/docker-images.yaml
@@ -1,9 +1,0 @@
-- dockerRepositoryId: autoscaler/prereleases
-  imageName: autoscale-dockerswarm-rabbit
-  tag: "2.0.0-914"
-- dockerRepositoryId: autoscaler/prereleases
-  imageName: autoscale-kubernetes-rabbit
-  tag: "2.0.0-914"
-- dockerRepositoryId: autoscaler/prereleases
-  imageName: autoscale-marathon-rabbit
-  tag: "2.0.0-914"


### PR DESCRIPTION
A bug in the auto-release has mistakenly left the sepg-release-info folder in the repo. The bug that caused this has been fixed, so I'm just dropping the left folder to allow this build to run without failing.