### PR TITLE
US919089: Disable zookeeper logs

### DIFF
--- a/autoscale-acceptance-tests/pom.xml
+++ b/autoscale-acceptance-tests/pom.xml
@@ -168,7 +168,7 @@
                                     <time>30000</time>
                                 </wait>
                                 <log>
-                                    <enabled>true</enabled>
+                                    <enabled>false</enabled>
                                 </log>
                             </run>
                         </image>

--- a/autoscale-acceptance-tests/pom.xml
+++ b/autoscale-acceptance-tests/pom.xml
@@ -137,7 +137,7 @@
                                     <time>20000</time>
                                 </wait>
                                 <log>
-                                    <enabled>true</enabled>
+                                    <enabled>false</enabled>
                                 </log>
                             </run>
                         </image>
@@ -168,7 +168,7 @@
                                     <time>30000</time>
                                 </wait>
                                 <log>
-                                    <enabled>false</enabled>
+                                    <enabled>true</enabled>
                                 </log>
                             </run>
                         </image>

--- a/autoscale-acceptance-tests/pom.xml
+++ b/autoscale-acceptance-tests/pom.xml
@@ -114,7 +114,7 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <verbose>true</verbose>
+                    <verbose>false</verbose>
                     <watchInterval>500</watchInterval>
                     <logDate>default</logDate>
                     <containerNamePattern>%a-%t</containerNamePattern>
@@ -168,7 +168,7 @@
                                     <time>30000</time>
                                 </wait>
                                 <log>
-                                    <enabled>true</enabled>
+                                    <enabled>false</enabled>
                                 </log>
                             </run>
                         </image>
@@ -209,7 +209,7 @@
                                     <time>30000</time>
                                 </wait>
                                 <log>
-                                    <enabled>true</enabled>
+                                    <enabled>false</enabled>
                                 </log>
                             </run>
                         </image>
@@ -236,7 +236,7 @@
                                     <time>120000</time>
                                 </wait>
                                 <log>
-                                    <enabled>true</enabled>
+                                    <enabled>false</enabled>
                                 </log>
                             </run>
                         </image>

--- a/pom.xml
+++ b/pom.xml
@@ -1181,7 +1181,7 @@
                         <image>
                             <repository>${dockerHubPublic}/library/zookeeper</repository>
                             <tag>3.9.2-jre-17</tag>
-                            <digest>sha256:e9a4fd7748598e7eac08cab3d28d7b2e6f092d5ec6509af3821b100924ceecb4</digest>
+                            <digest>sha256:62bc819222e46b25a83557f501923cb6a7e4c15baf14e767196f5a0cf4c7e555</digest>
                         </image>
                         <image>
                             <repository>${dockerHubPublic}/mesosphere/marathon</repository>

--- a/pom.xml
+++ b/pom.xml
@@ -1181,7 +1181,6 @@
                         <image>
                             <repository>${dockerHubPublic}/library/zookeeper</repository>
                             <tag>3.9.2-jre-17</tag>
-                            <digest>sha256:6b74c4a8332a04b041f4b189f3acef71c4a95280d48f15ddbc8c5d3245029e9b</digest>
                         </image>
                         <image>
                             <repository>${dockerHubPublic}/mesosphere/marathon</repository>

--- a/pom.xml
+++ b/pom.xml
@@ -1181,7 +1181,7 @@
                         <image>
                             <repository>${dockerHubPublic}/library/zookeeper</repository>
                             <tag>3.9.2-jre-17</tag>
-                            <digest>sha256:62bc819222e46b25a83557f501923cb6a7e4c15baf14e767196f5a0cf4c7e555</digest>
+                            <digest>sha256:6b74c4a8332a04b041f4b189f3acef71c4a95280d48f15ddbc8c5d3245029e9b</digest>
                         </image>
                         <image>
                             <repository>${dockerHubPublic}/mesosphere/marathon</repository>


### PR DESCRIPTION
https://internal.almoctane.com/ui/entity-navigation?p=131002/6001&entityType=work_item&id=919089

Since zookeeper version 3.8 it is shipped with logback configured by default.

This disables verbose logging and turns off logging for mesos/zookeeper images in tests. 

Log size dropped from 103Mb to 46Mb by disabling zookeeper logging
Log size dropped from 46Mb to 1.5Mb by disabling mesos logging