### PR TITLE
Add missing <name> to pom.xml

### DIFF
--- a/autoscale-acceptance-tests/pom.xml
+++ b/autoscale-acceptance-tests/pom.xml
@@ -23,6 +23,7 @@
     
     <groupId>com.github.autoscaler</groupId>
     <artifactId>autoscale-acceptance-tests</artifactId>
+    <name>autoscale-acceptance-tests</name>
     
     <parent>
         <groupId>com.github.autoscaler</groupId>

--- a/autoscale-api/pom.xml
+++ b/autoscale-api/pom.xml
@@ -23,6 +23,7 @@
 
     <groupId>com.github.autoscaler</groupId>
     <artifactId>autoscale-api</artifactId>
+    <name>autoscale-api</name>
 
     <parent>
         <groupId>com.github.autoscaler</groupId>

--- a/autoscale-core/pom.xml
+++ b/autoscale-core/pom.xml
@@ -23,6 +23,7 @@
 
     <groupId>com.github.autoscaler</groupId>
     <artifactId>autoscale-core</artifactId>
+    <name>autoscale-core</name>
 
     <parent>
         <groupId>com.github.autoscaler</groupId>

--- a/autoscale-email-alert-dispatcher/pom.xml
+++ b/autoscale-email-alert-dispatcher/pom.xml
@@ -28,6 +28,7 @@
     </parent>
 
     <artifactId>autoscale-email-alert-dispatcher</artifactId>
+    <name>autoscale-email-alert-dispatcher</name>
 
     <dependencies>
         <dependency>

--- a/autoscale-kubernetes-container/pom.xml
+++ b/autoscale-kubernetes-container/pom.xml
@@ -23,6 +23,7 @@
 
     <groupId>com.github.autoscaler</groupId>
     <artifactId>autoscale-kubernetes-container</artifactId>
+    <name>autoscale-kubernetes-container</name>
     <packaging>pom</packaging>
 
     <parent>

--- a/autoscale-kubernetes-shared/pom.xml
+++ b/autoscale-kubernetes-shared/pom.xml
@@ -23,6 +23,7 @@
 
     <groupId>com.github.autoscaler</groupId>
     <artifactId>autoscale-kubernetes-shared</artifactId>
+    <name>autoscale-kubernetes-shared</name>
     
     <parent>
         <artifactId>autoscale-aggregator</artifactId>

--- a/autoscale-scaler-kubernetes/pom.xml
+++ b/autoscale-scaler-kubernetes/pom.xml
@@ -23,6 +23,7 @@
 
     <groupId>com.github.autoscaler</groupId>
     <artifactId>autoscale-scaler-kubernetes</artifactId>
+    <name>autoscale-scaler-kubernetes</name>
 
     <parent>
         <groupId>com.github.autoscaler</groupId>

--- a/autoscale-source-kubernetes/pom.xml
+++ b/autoscale-source-kubernetes/pom.xml
@@ -23,6 +23,7 @@
 
     <groupId>com.github.autoscaler</groupId>
     <artifactId>autoscale-source-kubernetes</artifactId>
+    <name>autoscale-source-kubernetes</name>
     
     <parent>
         <artifactId>autoscale-aggregator</artifactId>

--- a/autoscale-workload-rabbit/pom.xml
+++ b/autoscale-workload-rabbit/pom.xml
@@ -23,6 +23,7 @@
 
     <groupId>com.github.autoscaler</groupId>
     <artifactId>autoscale-workload-rabbit</artifactId>
+    <name>autoscale-workload-rabbit</name>
 
     <parent>
         <groupId>com.github.autoscaler</groupId>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -23,6 +23,7 @@
 
     <groupId>com.github.autoscaler</groupId>
     <artifactId>autoscaler-docs</artifactId>
+    <name>autoscaler-docs</name>
     <packaging>pom</packaging>
 
     <parent>


### PR DESCRIPTION
This PR adds missing <name> tags to pom.xml files using their corresponding <artifactId> values, ensuring they're not added inside <parent> blocks.

https://internal.almoctane.com/ui/entity-navigation?p=131002/6001&entityType=work_item&id=1029210
